### PR TITLE
topic/grapito#37 spdlog integration

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Cache Conan local data
         uses: actions/cache@v2
         env:
-          cache-name: conan-cacheb
+          # The secret is used as a variable, to allow invalidating all caches at once.
+          cache-name: conan-${{ secrets.ACTION_CACHENAME }}
         with:
           # Exclude opengl/system because its build is responsible to install opengl system-wide.
           # (required on current Linux runner)

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -28,6 +28,7 @@ class GraphicsConan(ConanFile):
         ("glad/0.1.34"),
         ("glfw/3.3.4"),
         ("nlohmann_json/3.9.1"),
+        ("spdlog/1.9.2"),
 
         ("math/64e6aa9451@adnn/develop"),
     )

--- a/src/lib/arte/arte/CMakeLists.txt
+++ b/src/lib/arte/arte/CMakeLists.txt
@@ -15,6 +15,10 @@ add_library(${TARGET_NAME}
     ${${TARGET_NAME}_HEADERS}
 )
 
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
 add_library(ad::${TARGET_NAME} ALIAS ${TARGET_NAME})
 
 cmc_target_current_include_directory(${TARGET_NAME})

--- a/src/lib/graphics/graphics/AppInterface.cpp
+++ b/src/lib/graphics/graphics/AppInterface.cpp
@@ -1,5 +1,9 @@
 #include "AppInterface.h"
 
+#include "detail/Logging.h"
+
+#include <sstream>
+
 
 namespace ad {
 namespace graphics {
@@ -19,6 +23,9 @@ AppInterface::AppInterface() :
 
     // Frame buffer clear color
     glClearColor(0.1f, 0.2f, 0.3f, 1.f);
+
+    // Initialize logging (as this class should be instantiated in any case)
+    detail::initializeLogging();
 }
 
 
@@ -45,6 +52,30 @@ void AppInterface::callbackFramebufferSize(int width, int height)
 void AppInterface::clear()
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
+}
+
+
+void GLAPIENTRY AppInterface::OpenGLMessageLogging(GLenum source,
+                                                   GLenum type,
+                                                   GLuint id,
+                                                   GLenum severity,
+                                                   GLsizei length,
+                                                   const GLchar* message,
+                                                   const void* userParam)
+{
+    std::ostringstream oss;
+    oss << "(type = 0x" << type
+        << ", severity = 0x" << severity
+        << ")\n" << message
+    ;
+    if (type == GL_DEBUG_TYPE_ERROR)
+    {
+        LOG(opengl, error)(oss.str());
+    }
+    else
+    {
+        LOG(opengl, info)(oss.str());
+    }
 }
 
 } // namespace graphics

--- a/src/lib/graphics/graphics/AppInterface.h
+++ b/src/lib/graphics/graphics/AppInterface.h
@@ -50,6 +50,14 @@ public:
     /// \brief To be called by the application when it has cursor position events to provide
     void callbackCursorPosition(double xpos, double ypos);
 
+    static void GLAPIENTRY OpenGLMessageLogging(GLenum source,
+                                                GLenum type,
+                                                GLuint id,
+                                                GLenum severity,
+                                                GLsizei length,
+                                                const GLchar* message,
+                                                const void* userParam);
+
 private:
     Size2<int> mWindowSize;
     Size2<int> mFramebufferSize;

--- a/src/lib/graphics/graphics/ApplicationGlfw.h
+++ b/src/lib/graphics/graphics/ApplicationGlfw.h
@@ -82,7 +82,7 @@ public:
         }
         else
         {
-            enableDebugOutput();
+            enableDebugOutput(&AppInterface::OpenGLMessageLogging);
         }
     }
 

--- a/src/lib/graphics/graphics/CMakeFinds.cmake.in
+++ b/src/lib/graphics/graphics/CMakeFinds.cmake.in
@@ -4,3 +4,4 @@
 @find_package@(nlohmann_json 3.9 @REQUIRED@)
 @find_package@(glad @REQUIRED@)
 @find_package@(glfw3 3.3 @REQUIRED@)
+@find_package@(spdlog REQUIRED COMPONENTS libspdlog)

--- a/src/lib/graphics/graphics/CMakeLists.txt
+++ b/src/lib/graphics/graphics/CMakeLists.txt
@@ -18,6 +18,8 @@ set(${TARGET_NAME}_HEADERS
     Vertex.h
 
     dataformat/tiles.h
+
+    detail/Logging.h
 )
 
 set(${TARGET_NAME}_SOURCES
@@ -30,6 +32,12 @@ set(${TARGET_NAME}_SOURCES
     DrawLine.cpp
 
     dataformat/tiles.cpp
+
+    detail/Logging.cpp
+)
+
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
 )
 
 add_library(${TARGET_NAME}
@@ -60,7 +68,9 @@ target_link_libraries(${TARGET_NAME}
         ad::handy
         ad::resource
 
-        nlohmann_json::nlohmann_json)
+        nlohmann_json::nlohmann_json
+        spdlog::libspdlog
+)
 
 
 ##

--- a/src/lib/graphics/graphics/detail/Logging.cpp
+++ b/src/lib/graphics/graphics/detail/Logging.cpp
@@ -1,0 +1,22 @@
+#include "Logging.h"
+
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+
+namespace ad {
+namespace graphics {
+namespace detail {
+
+
+void initializeLogging()
+{
+    // Intended for message issued by opengl
+    spdlog::stdout_color_mt("opengl"); 
+    // Intended for the actual library messages
+    spdlog::stdout_color_mt("graphics"); 
+};
+
+
+} // namespace detail
+} // namespace graphics
+} // namespace ad

--- a/src/lib/graphics/graphics/detail/Logging.h
+++ b/src/lib/graphics/graphics/detail/Logging.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+
+#define LOG(logger, severity) spdlog::get(#logger)->severity
+
+
+namespace ad {
+namespace graphics {
+namespace detail {
+
+
+/// Will be called on AppInterface construction, must be called explicitly if it is not instanciated.
+void initializeLogging();
+
+
+} // namespace detail
+} // namespace graphics
+} // namespace ad

--- a/src/lib/handy/handy/CMakeLists.txt
+++ b/src/lib/handy/handy/CMakeLists.txt
@@ -10,6 +10,10 @@ set(${TARGET_NAME}_HEADERS
     ZeroOnMove.h
 )
 
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
 add_library(${TARGET_NAME} INTERFACE)
 
 add_library(ad::${TARGET_NAME} ALIAS ${TARGET_NAME})

--- a/src/lib/platform/platform/CMakeLists.txt
+++ b/src/lib/platform/platform/CMakeLists.txt
@@ -4,6 +4,10 @@ set(${TARGET_NAME}_HEADERS
     Filesystem.h
 )
 
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
 # NOTE should evolve into a compiled module
 add_library(${TARGET_NAME} INTERFACE)
 

--- a/src/lib/renderer/renderer/CMakeLists.txt
+++ b/src/lib/renderer/renderer/CMakeLists.txt
@@ -26,6 +26,10 @@ set(${TARGET_NAME}_SOURCES
     stb_image.c
 )
 
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
 add_library(${TARGET_NAME}
     ${${TARGET_NAME}_SOURCES}
     ${${TARGET_NAME}_HEADERS}

--- a/src/lib/renderer/renderer/Error.h
+++ b/src/lib/renderer/renderer/Error.h
@@ -27,10 +27,10 @@ MessageCallback( GLenum source,
 }
 
 // During init, can be used to enable debug output
-inline void enableDebugOutput()
+inline void enableDebugOutput(decltype(MessageCallback) aOutputCallback = &MessageCallback)
 {
     glEnable              ( GL_DEBUG_OUTPUT );
-    glDebugMessageCallback( &MessageCallback, 0 );
+    glDebugMessageCallback( aOutputCallback, 0 );
 }
 
 struct [[nodiscard]] ErrorCheck

--- a/src/lib/resource/resource/CMakeLists.txt
+++ b/src/lib/resource/resource/CMakeLists.txt
@@ -9,6 +9,10 @@ set(${TARGET_NAME}_HEADERS
     #${CMAKE_CURRENT_BINARY_DIR}/build_config.h
 )
 
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
 add_library(${TARGET_NAME} INTERFACE)
 
 add_library(ad::${TARGET_NAME} ALIAS ${TARGET_NAME})


### PR DESCRIPTION
- Add spdlog, uses it to log the OpenGL message instead of write to cerr.
- Use the dedicated organization secret as part of cache name.
