### PR TITLE
fix/graphics#33 handle window minimize

### DIFF
--- a/src/lib/graphics/graphics/AppInterface.cpp
+++ b/src/lib/graphics/graphics/AppInterface.cpp
@@ -57,10 +57,8 @@ void AppInterface::callbackWindowSize(int width, int height)
     mWindowSize.width() = width;
     mWindowSize.height() = height;
 
-    //for (auto & listener : mSizeCallbacks)
-    //{
-    //    listener({width, height});
-    //}
+    // NOTE Ad 2022/01/07: It is not possible to listen to the windows resize event for the moment
+    // So there are no notifications to send.
 }
 
 void AppInterface::callbackFramebufferSize(int width, int height)

--- a/src/lib/graphics/graphics/AppInterface.cpp
+++ b/src/lib/graphics/graphics/AppInterface.cpp
@@ -36,8 +36,23 @@ void AppInterface::requestCloseApplication()
 }
 
 
+void AppInterface::callbackWindowMinimize(bool aMinimized)
+{
+    if (aMinimized)
+    {
+        LOG(graphics, info)("The window has be minimized.");
+    }
+    else
+    {
+        LOG(graphics, info)("The window has be restored.");
+    }
+    mWindowIsMinimized = aMinimized;
+}
+
+
 void AppInterface::callbackWindowSize(int width, int height)
 {
+    LOG(graphics, debug)("The window has been resized to ({}, {}).", width, height);
     //glViewport(0, 0, width, height);
     mWindowSize.width() = width;
     mWindowSize.height() = height;
@@ -50,10 +65,14 @@ void AppInterface::callbackWindowSize(int width, int height)
 
 void AppInterface::callbackFramebufferSize(int width, int height)
 {
+    LOG(graphics, debug)("The framebuffer has been resized to ({}, {}).", width, height);
     glViewport(0, 0, width, height);
     mFramebufferSize.width() = width;
     mFramebufferSize.height() = height;
-    mFramebufferSizeSubject.dispatch(Size2<int>{width, height});
+    if (!mWindowIsMinimized)
+    {
+        mFramebufferSizeSubject.dispatch(mFramebufferSize);
+    }
 }
 
 void AppInterface::clear()

--- a/src/lib/graphics/graphics/AppInterface.h
+++ b/src/lib/graphics/graphics/AppInterface.h
@@ -39,6 +39,9 @@ public:
     template <class T_cursorPositionCallback>
     void registerCursorPositionCallback(T_cursorPositionCallback && mCallback);
 
+    /// \brief To be called by the application when the Window is minimized (iconified).
+    void callbackWindowMinimize(bool aMinimized);
+
     /// \brief To be called by the application when the Window is resized
     void callbackWindowSize(int width, int height);
     /// \brief To be called by the application when the Framebuffer is resized
@@ -62,6 +65,7 @@ public:
                                                 const void* userParam);
 
 private:
+    bool mWindowIsMinimized{false};
     Size2<int> mWindowSize;
     Size2<int> mFramebufferSize;
     Subject<SizeListener> mFramebufferSizeSubject;

--- a/src/lib/graphics/graphics/ApplicationGlfw.h
+++ b/src/lib/graphics/graphics/ApplicationGlfw.h
@@ -60,13 +60,14 @@ public:
             // (yet not invoking the size callback)
             int width, height;
             glfwGetWindowSize(mWindow, &width, &height);
-            windowsSize_callback(mWindow, width, height);
+            windowSize_callback(mWindow, width, height);
 
             glfwGetFramebufferSize(mWindow, &width, &height);
             framebufferSize_callback(mWindow, width, height);
         }
 
-        glfwSetWindowSizeCallback(mWindow, windowsSize_callback);
+        glfwSetWindowIconifyCallback(mWindow, windowMinimize_callback);
+        glfwSetWindowSizeCallback(mWindow, windowSize_callback);
         glfwSetFramebufferSizeCallback(mWindow, framebufferSize_callback);
 
         using namespace std::placeholders;
@@ -190,7 +191,13 @@ private:
         appInterface->callbackCursorPosition(xpos, ypos);
     }
 
-    static void windowsSize_callback(GLFWwindow * window, int width, int height)
+    static void windowMinimize_callback(GLFWwindow * window, int iconified)
+    {
+        AppInterface * appInterface = static_cast<AppInterface *>(glfwGetWindowUserPointer(window));
+        appInterface->callbackWindowMinimize(iconified);
+    }
+
+    static void windowSize_callback(GLFWwindow * window, int width, int height)
     {
         AppInterface * appInterface = static_cast<AppInterface *>(glfwGetWindowUserPointer(window));
         appInterface->callbackWindowSize(width, height);

--- a/src/lib/graphics/graphics/Spriting.h
+++ b/src/lib/graphics/graphics/Spriting.h
@@ -54,6 +54,9 @@ public:
 
     void updateInstances(gsl::span<const Instance> aInstances);
 
+    // TODO Externalize the VertexSpecification in a dedicated struct, and take it as an argument.
+    // It would be more flexible, and remove some constness issues (seen Grapito Render system).
+    // The dedicated struct type maintains static format safety.
     void render(const sprite::LoadedAtlas & aAtlas) const;
 
     /// \brief Define the size of a pixel in world units.


### PR DESCRIPTION
closes #33

- Minor: Add a TODO comment on Spriting.
- Disable framebuffer size callback while window is minimized.
- Minor: Note to clarify the fact there are no window size listeners.
