### PR TITLE
topic/graphics#35 allow fullscreen

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -28,7 +28,7 @@ class GraphicsConan(ConanFile):
         ("boost/1.77.0"),
         ("freetype/2.11.0"),
         ("glad/0.1.34"),
-        ("glfw/3.3.4"),
+        ("glfw/3.3.6"),
         ("nlohmann_json/3.9.1"),
         ("spdlog/1.9.2"),
         ("utfcpp/3.2.1"),

--- a/src/app/samples/curving/curving/main.cpp
+++ b/src/app/samples/curving/curving/main.cpp
@@ -19,9 +19,9 @@ int main(int argc, const char * argv[])
     try
     {
         ApplicationGlfw application("Curving", 1600, 1000,
-                                 ApplicationGlfw::Flags::None,
-                                 4, 1,
-                                 { {GLFW_SAMPLES, 8} });
+                                    ApplicationFlag::None,
+                                    4, 1,
+                                    { {GLFW_SAMPLES, 8} });
 
         Timer timer{glfwGetTime(), 0.};
 

--- a/src/app/samples/texting/texting/main.cpp
+++ b/src/app/samples/texting/texting/main.cpp
@@ -101,8 +101,7 @@ int main(int argc, const char * argv[])
 
         // I suspect this is the default anyway
         //SetConsoleCP(CP_ACP);
-        ApplicationGlfw application("Texting", 1600, 1000,
-                                    ApplicationGlfw::Flags::None);
+        ApplicationGlfw application("Texting", 1600, 1000);
 
         Timer timer{glfwGetTime(), 0.};
         Scene scene{resource::pathFor("fonts/dejavu-fonts-ttf-2.37/DejaVuSans.ttf"),

--- a/src/lib/graphics/graphics/ApplicationGlfw.h
+++ b/src/lib/graphics/graphics/ApplicationGlfw.h
@@ -96,6 +96,16 @@ public:
 
         glfwShowWindow(mWindow);
 
+        // TODO Ad 2022/01/27: Going fullscreen after showing is not optimal, since we can see the window for a few frames
+        // Yet, currently if it is made fullscreen before showing, it does not have focus...
+        // Note that the problem of focus is not present if the windows is directly made fullscreen in glfwCreateWindow().
+        if ((aFlags & ApplicationFlag::Fullscreen) != ApplicationFlag::None)
+        {
+            GLFWmonitor * monitor = glfwGetPrimaryMonitor();
+            const GLFWvidmode * mode = glfwGetVideoMode(monitor);
+            glfwSetWindowMonitor(mWindow, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+        }
+
         // VSync
         glfwSwapInterval(1);
 
@@ -257,6 +267,7 @@ private:
         auto window = guard(glfwCreateWindow(aWidth,
                                              aHeight,
                                              aName.c_str(),
+                                             //glfwGetPrimaryMonitor(),
                                              NULL,
                                              NULL),
                             glfwDestroyWindow);

--- a/src/lib/graphics/graphics/ApplicationGlfw.h
+++ b/src/lib/graphics/graphics/ApplicationGlfw.h
@@ -5,30 +5,44 @@
 #include <renderer/Error.h>
 #include <renderer/GL_Loader.h>
 
+#include <handy/Bitmask.h>
 #include <handy/Guard.h>
 
 #include <GLFW/glfw3.h>
 
 #include <memory>
 
+
 namespace ad {
 namespace graphics {
 
 
+enum class ApplicationFlag
+{
+    None = 0,
+    Window_Keep_Ratio = (1 << 1),
+    Fullscreen = (1 << 2),
+};
+
+
+} // namespace graphics
+
+
+template <>
+struct is_bitmask<graphics::ApplicationFlag> : public std::true_type
+{};
+
+
+namespace graphics {
+
 class ApplicationGlfw
 {
 public:
-    enum Flags
-    {
-        None = 0,
-        Window_Keep_Ratio = (1 << 1),
-    };
-
     using WindowHints = std::initializer_list<std::pair</*GLFW int*/int, /*value*/int>>;
 
     ApplicationGlfw(const std::string & aName,
                     math::Size<2, int> aSize,
-                    Flags aFlags = None,
+                    ApplicationFlag aFlags = ApplicationFlag::None,
                     int aGLVersionMajor=4, int aGLVersionMinor=1,
                     WindowHints aCustomWindowHints = {}) :
         ApplicationGlfw{aName, aSize.width(), aSize.height(), aFlags, aGLVersionMajor, aGLVersionMinor, aCustomWindowHints}
@@ -36,13 +50,13 @@ public:
 
     ApplicationGlfw(const std::string & aName,
                     int aWidth, int aHeight,
-                    Flags aFlags = None,
+                    ApplicationFlag aFlags = ApplicationFlag::None,
                     int aGLVersionMajor=4, int aGLVersionMinor=1,
                     WindowHints aCustomWindowHints = {}) :
         mGlfwInitialization(initializeGlfw()),
         mWindow(initializeWindow(aName, aWidth, aHeight, aGLVersionMajor, aGLVersionMinor, aCustomWindowHints))
     {
-        if (aFlags & Window_Keep_Ratio)
+        if ((aFlags & ApplicationFlag::Window_Keep_Ratio) != ApplicationFlag::None)
         {
             glfwSetWindowAspectRatio(mWindow, aWidth, aHeight);
         }

--- a/src/lib/handy/handy/Bitmask.h
+++ b/src/lib/handy/handy/Bitmask.h
@@ -1,0 +1,40 @@
+#pragma once
+
+
+#include <type_traits>
+
+
+// Note: putting it in handy subnamespace would make the operators difficult to use.
+namespace ad {
+
+
+template <class>
+struct is_bitmask : public std::false_type
+{};
+
+
+template <class T>
+constexpr bool is_bitmask_v = is_bitmask<T>::value;
+
+
+template <class T_enumClass>
+requires is_bitmask_v<T_enumClass>
+T_enumClass operator|(T_enumClass aLhs, T_enumClass aRhs)
+{
+    return static_cast<T_enumClass>(
+        static_cast<std::underlying_type_t<T_enumClass>>(aLhs)
+        | static_cast<std::underlying_type_t<T_enumClass>>(aRhs));
+}
+
+
+template <class T_enumClass>
+requires is_bitmask_v<T_enumClass>
+T_enumClass operator&(T_enumClass aLhs, T_enumClass aRhs)
+{
+    return static_cast<T_enumClass>(
+        static_cast<std::underlying_type_t<T_enumClass>>(aLhs)
+        & static_cast<std::underlying_type_t<T_enumClass>>(aRhs));
+}
+
+
+} // namespace ad

--- a/src/lib/handy/handy/Bitmask.h
+++ b/src/lib/handy/handy/Bitmask.h
@@ -4,6 +4,14 @@
 #include <type_traits>
 
 
+// TODO Ad 31/01/2022: This approach has semantic issues.
+// Most notably, the bitwise operators might create enumerators that are not present
+// is the scoped enum.
+// There should probably be a strongly typed distinction between the base enumerators
+// and a value constructed by combining those enumerators.
+// (E.g. The enumerator could be used as positions for a std::bitset, wich would be the actual value).
+
+
 // Note: putting it in handy subnamespace would make the operators difficult to use.
 namespace ad {
 
@@ -29,11 +37,29 @@ T_enumClass operator|(T_enumClass aLhs, T_enumClass aRhs)
 
 template <class T_enumClass>
 requires is_bitmask_v<T_enumClass>
+T_enumClass & operator|=(T_enumClass & aLhs, T_enumClass aRhs)
+{
+    aLhs = aLhs | aRhs;
+    return aLhs;
+}
+
+
+template <class T_enumClass>
+requires is_bitmask_v<T_enumClass>
 T_enumClass operator&(T_enumClass aLhs, T_enumClass aRhs)
 {
     return static_cast<T_enumClass>(
         static_cast<std::underlying_type_t<T_enumClass>>(aLhs)
         & static_cast<std::underlying_type_t<T_enumClass>>(aRhs));
+}
+
+
+template <class T_enumClass>
+requires is_bitmask_v<T_enumClass>
+T_enumClass & operator&=(T_enumClass & aLhs, T_enumClass aRhs)
+{
+    aLhs = aLhs & aRhs;
+    return aLhs;
 }
 
 

--- a/src/lib/handy/handy/Bitmask.h
+++ b/src/lib/handy/handy/Bitmask.h
@@ -37,4 +37,12 @@ T_enumClass operator&(T_enumClass aLhs, T_enumClass aRhs)
 }
 
 
+template <class T_enumClass>
+requires is_bitmask_v<T_enumClass>
+bool test(T_enumClass aFlags, T_enumClass aTested)
+{
+    return (aFlags & aTested) == aTested;
+}
+
+
 } // namespace ad

--- a/src/lib/handy/handy/CMakeLists.txt
+++ b/src/lib/handy/handy/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TARGET_NAME handy)
 
 set(${TARGET_NAME}_HEADERS
     array_utils.h
+    Bitmask.h
     Crc.h
     Guard.h
     Observer.h


### PR DESCRIPTION
closes #35

- Implement "Bitmask" helpers in handy, used for ApplicationGlfw flags.
- First attempt: go fullscreen after showing window.
- Go fullscreen directly at window creation, use current mode resolution.
- Provide compound bitwise operation in Bitmask, add TODO note.
