### PR TITLE
topic/graphics#40 sprite rotation

### DIFF
--- a/src/lib/graphics/graphics/Curving-shaders.h
+++ b/src/lib/graphics/graphics/Curving-shaders.h
@@ -87,11 +87,11 @@ const GLchar* gFragmentShader = R"#(
 
     out vec4 out_Color;
 
-    uniform vec3 u_color;
+    uniform vec4 u_color;
 
     void main(void)
     {
-        out_Color = vec4(u_color, 1.0);
+        out_Color = u_color;
     }
 )#";
 

--- a/src/lib/graphics/graphics/Curving.cpp
+++ b/src/lib/graphics/graphics/Curving.cpp
@@ -78,7 +78,7 @@ Curving::Curving(GLsizei aCurveSubdivisions, math::AffineMatrix<4, GLfloat> aPro
     setCameraTransformation(math::AffineMatrix<4, GLfloat>::Identity());
     setProjectionTransformation(aProjectionTransformation);
 
-    setUniform(mGpuProgram, "u_color", math::hdr::gWhite); 
+    setColor(math::hdr::gWhite);
 }
 
 
@@ -93,6 +93,12 @@ void Curving::render(gsl::span<const Instance> aInstances) const
                           0,
                           mVertexCount,
                           static_cast<GLsizei>(aInstances.size()));
+}
+
+
+void Curving::setColor(math::hdr::Rgba aColor)
+{
+    setUniform(mGpuProgram, "u_color", aColor);
 }
 
 

--- a/src/lib/graphics/graphics/Curving.h
+++ b/src/lib/graphics/graphics/Curving.h
@@ -32,6 +32,8 @@ public:
 
     void render(gsl::span<const Instance> aInstances) const;
 
+    void setColor(math::hdr::Rgba aColor);
+
     void setCameraTransformation(const math::AffineMatrix<4, GLfloat> & aTransformation);
     void setProjectionTransformation(const math::AffineMatrix<4, GLfloat> & aTransformation);
 

--- a/src/lib/graphics/graphics/Sprite.h
+++ b/src/lib/graphics/graphics/Sprite.h
@@ -16,6 +16,13 @@ namespace graphics {
 using SpriteArea = arte::SpriteArea;
 
 // Implementer's note: Leave room for potential future optimization, by changing this type.
+// (What I had in mind is a single index into a uniform array containing the different sprite areas.
+// This uniform array would become part of the LoadedAtlas.)
+// TODO Ad 2022/02/10: Should it also keep a reference to the texture / the loaded atlas?
+// This way it would be more autonomous, instead of having clients maintain the relationship on their own.
+// On the other hand, it could break the API approach currently taken in Tiling.
+// (i.e. Tiling::render(const sprite::LoadedAtlas & aAtlas, const TileSet & aTileSet))
+// And grow the loadedsprite significantly (with a lot of duplication in container of animation frames...).
 using LoadedSprite = SpriteArea;
 
 

--- a/src/lib/graphics/graphics/SpriteLoading.cpp
+++ b/src/lib/graphics/graphics/SpriteLoading.cpp
@@ -8,7 +8,7 @@ namespace graphics {
 namespace sprite {
 
 
-std::pair<LoadedAtlas, std::vector<LoadedSprite>> loadMetaFile(const filesystem::path & aPath)
+SheetLoad loadMetaFile(const filesystem::path & aPath)
 {
     arte::TileSheet sheet = arte::TileSheet::LoadMetaFile(aPath);
     return load(sheet.cbegin(), sheet.cend(), sheet.image());

--- a/src/lib/graphics/graphics/SpriteLoading.h
+++ b/src/lib/graphics/graphics/SpriteLoading.h
@@ -19,6 +19,10 @@ struct LoadedAtlas
 };
 
 
+using SheetLoad = std::pair<LoadedAtlas, std::vector<LoadedSprite>>;
+using SingleLoad = std::pair<LoadedAtlas, LoadedSprite>;
+
+
 /// \attention This signature is not stable
 template <class T_pixel>
 LoadedAtlas loadAtlas(const arte::Image<T_pixel> & aRasterData);
@@ -26,25 +30,21 @@ LoadedAtlas loadAtlas(const arte::Image<T_pixel> & aRasterData);
 
 /// \brief Takes a pair of iterator to SpriteArea instances, and the corresponding raster data
 template <class T_iterator, class T_pixel>
-std::pair<LoadedAtlas, std::vector<LoadedSprite>>
-load(T_iterator aFirst, T_iterator aLast, const arte::Image<T_pixel> & aRasterData);
+SheetLoad load(T_iterator aFirst, T_iterator aLast, const arte::Image<T_pixel> & aRasterData);
 
 
 /// \brief Overload accepting a range.
 template <std::ranges::range T_range, class T_pixel>
-std::pair<LoadedAtlas, std::vector<LoadedSprite>>
-load(T_range aRange, const arte::Image<T_pixel> & aRasterData);
+SheetLoad load(T_range aRange, const arte::Image<T_pixel> & aRasterData);
 
 
 /// \brief Load all sprites defined in the meta (tilesheet) file.
-std::pair<LoadedAtlas, std::vector<LoadedSprite>>
-loadMetaFile(const filesystem::path & aPath);
+SheetLoad loadMetaFile(const filesystem::path & aPath);
 
 
 /// \brief Load the entire image as a single sprite.
 template <class T_pixel>
-std::pair<LoadedAtlas, LoadedSprite>
-load(const arte::Image<T_pixel> & aRasterData);
+SingleLoad load(const arte::Image<T_pixel> & aRasterData);
 
 
 //
@@ -61,8 +61,7 @@ LoadedAtlas loadAtlas(const arte::Image<T_pixel> & aRasterData)
 
 
 template <class T_iterator, class T_pixel>
-std::pair<LoadedAtlas, std::vector<LoadedSprite>>
-load(T_iterator aFirst, T_iterator aLast, const arte::Image<T_pixel> & aRasterData)
+SheetLoad load(T_iterator aFirst, T_iterator aLast, const arte::Image<T_pixel> & aRasterData)
 {
     static_assert(std::is_convertible_v<decltype(*std::declval<T_iterator>()), SpriteArea>,
                   "Iterators must point to SpriteArea instances.");
@@ -74,16 +73,14 @@ load(T_iterator aFirst, T_iterator aLast, const arte::Image<T_pixel> & aRasterDa
 
 
 template <std::ranges::range T_range, class T_pixel>
-std::pair<LoadedAtlas, std::vector<LoadedSprite>>
-load(T_range aRange, const arte::Image<T_pixel> & aRasterData)
+SheetLoad load(T_range aRange, const arte::Image<T_pixel> & aRasterData)
 {
     return load(std::begin(aRange), std::end(aRange), aRasterData);
 }
 
 
 template <class T_pixel>
-std::pair<LoadedAtlas, LoadedSprite>
-load(const arte::Image<T_pixel> & aRasterData)
+SingleLoad load(const arte::Image<T_pixel> & aRasterData)
 {
     std::array<SpriteArea, 1> fullSize{ SpriteArea{{0, 0}, aRasterData.dimensions()} };
     LoadedAtlas atlas;

--- a/src/lib/graphics/graphics/Spriting.cpp
+++ b/src/lib/graphics/graphics/Spriting.cpp
@@ -68,12 +68,14 @@ VertexSpecification makeQuad()
         initVertexBuffer<Spriting::Instance>(
             specification.mVertexArray,
             {
-                // Sprite position
-                { 2,                               2, offsetof(Spriting::Instance, mPosition),      MappedGL<GLfloat>::enumerator},
+                // Model transform
+                { 2, 3, offsetof(Spriting::Instance, mModelTransform) + 0 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator},
+                { 3, 3, offsetof(Spriting::Instance, mModelTransform) + 3 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator},
+                { 4, 3, offsetof(Spriting::Instance, mModelTransform) + 6 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator},
                 // LoadedSprite (i.e. sprite rectangle cutout in the texture)
-                { {3, Attribute::Access::Integer}, 4, offsetof(Spriting::Instance, mLoadedSprite),  MappedGL<GLint>::enumerator},
-                { 4,                               1, offsetof(Spriting::Instance, mOpacity),       MappedGL<GLfloat>::enumerator},
-                { 5,                               2, offsetof(Spriting::Instance, mAxisMirroring), MappedGL<GLint>::enumerator},
+                { {5, Attribute::Access::Integer}, 4, offsetof(Spriting::Instance, mLoadedSprite),  MappedGL<GLint>::enumerator},
+                { 6,                               1, offsetof(Spriting::Instance, mOpacity),       MappedGL<GLfloat>::enumerator},
+                { 7,                               2, offsetof(Spriting::Instance, mAxisMirroring), MappedGL<GLint>::enumerator},
             },
             1
         ));
@@ -96,6 +98,28 @@ Program makeProgram()
 }
 
 } // anonymous namespace
+
+
+Spriting::Instance::Instance(math::AffineMatrix<3, GLfloat> aModelTransform,
+                             LoadedSprite aSprite,
+                             GLfloat aOpacity,
+                             Vec2<int> aAxisMirroring) :
+    mModelTransform{aModelTransform},
+    mLoadedSprite{std::move(aSprite)},
+    mOpacity{aOpacity},
+    mAxisMirroring{std::move(aAxisMirroring)}
+{}
+
+
+Spriting::Instance::Instance(Position2<GLfloat> aRenderingPosition, 
+                             LoadedSprite aSprite,
+                             GLfloat aOpacity,
+                             Vec2<int> aAxisMirroring) :
+    Instance{math::trans2d::translate(aRenderingPosition.as<math::Vec>()), 
+             aSprite,
+             aOpacity,
+             aAxisMirroring}
+{}
 
 
 Spriting::Spriting(GLfloat aPixelSize) :

--- a/src/lib/graphics/graphics/Spriting.cpp
+++ b/src/lib/graphics/graphics/Spriting.cpp
@@ -103,22 +103,25 @@ Program makeProgram()
 Spriting::Instance::Instance(math::AffineMatrix<3, GLfloat> aModelTransform,
                              LoadedSprite aSprite,
                              GLfloat aOpacity,
-                             Vec2<int> aAxisMirroring) :
+                             Mirroring aMirroring) :
     mModelTransform{aModelTransform},
     mLoadedSprite{std::move(aSprite)},
     mOpacity{aOpacity},
-    mAxisMirroring{std::move(aAxisMirroring)}
+    mAxisMirroring{
+        (test(aMirroring, Mirroring::FlipHorizontal) ? -1 : 1),
+        (test(aMirroring, Mirroring::FlipVertical) ? -1 : 1)
+    }
 {}
 
 
 Spriting::Instance::Instance(Position2<GLfloat> aRenderingPosition, 
                              LoadedSprite aSprite,
                              GLfloat aOpacity,
-                             Vec2<int> aAxisMirroring) :
+                             Mirroring aMirroring) :
     Instance{math::trans2d::translate(aRenderingPosition.as<math::Vec>()), 
              aSprite,
              aOpacity,
-             aAxisMirroring}
+             aMirroring}
 {}
 
 

--- a/src/lib/graphics/graphics/Spriting.h
+++ b/src/lib/graphics/graphics/Spriting.h
@@ -25,13 +25,16 @@ class Spriting
 public:
     struct Instance
     {
-        Instance(Position2<GLfloat> aRenderingPosition, LoadedSprite aSprite, GLfloat aOpacity = 1.f, Vec2<int> aAxisMirroring = {1, 1}):
-            mPosition{std::move(aRenderingPosition)},
-            mLoadedSprite{std::move(aSprite)},
-            mOpacity{aOpacity},
-            mAxisMirroring{std::move(aAxisMirroring)}
-        {}
+        Instance(math::AffineMatrix<3, GLfloat> aModelTransform,
+                 LoadedSprite aSprite,
+                 GLfloat aOpacity = 1.f,
+                 Vec2<int> aAxisMirroring = {1, 1}); 
 
+        Instance(Position2<GLfloat> aRenderingPosition, 
+                 LoadedSprite aSprite,
+                 GLfloat aOpacity = 1.f,
+                 Vec2<int> aAxisMirroring = {1, 1});
+            
         Instance & mirrorHorizontal(bool aMirror = true)
         {
             mAxisMirroring.x() = aMirror ? -1 : 1;
@@ -44,7 +47,7 @@ public:
             return *this; 
         }
 
-        Position2<GLfloat> mPosition;
+        math::AffineMatrix<3, GLfloat> mModelTransform;
         LoadedSprite mLoadedSprite;
         GLfloat mOpacity;
         Vec2<int> mAxisMirroring;

--- a/src/lib/graphics/graphics/Spriting.h
+++ b/src/lib/graphics/graphics/Spriting.h
@@ -4,6 +4,8 @@
 
 #include "Sprite.h"
 
+#include <handy/Bitmask.h>
+
 #include <math/Homogeneous.h>
 
 #include <renderer/Drawing.h>
@@ -28,24 +30,30 @@ public:
         Instance(math::AffineMatrix<3, GLfloat> aModelTransform,
                  LoadedSprite aSprite,
                  GLfloat aOpacity = 1.f,
-                 Vec2<int> aAxisMirroring = {1, 1}); 
+                 Mirroring aMirroring = Mirroring::None); 
 
         Instance(Position2<GLfloat> aRenderingPosition, 
                  LoadedSprite aSprite,
                  GLfloat aOpacity = 1.f,
-                 Vec2<int> aAxisMirroring = {1, 1});
+                 Mirroring aMirroring = Mirroring::None);
             
-        Instance & mirrorHorizontal(bool aMirror = true)
-        {
-            mAxisMirroring.x() = aMirror ? -1 : 1;
-            return *this; 
-        }
-
-        Instance & mirrorVertical(bool aMirror = true)
-        {
-            mAxisMirroring.y() = aMirror ? -1 : 1;
-            return *this; 
-        }
+        // NOTE Ad 2022/02/11: Ideally the mirroring would be embedded in the model transform
+        // Yet, this causes a complication since the sprite origin is at its bottom left corner.
+        // The translation to apply is dependent on the sprite dimension, and the spriting render
+        // "pixelToWorld" factor.
+        // So we keep the mirroring as separate data applied to uv coordinates for the moment, but remove
+        // these member functions from the API to simplify if one day we embed it in model transform.
+        //Instance & mirrorHorizontal(bool aMirror = true)
+        //{
+        //    mAxisMirroring.x() = aMirror ? -1 : 1;
+        //    return *this; 
+        //}
+        //
+        //Instance & mirrorVertical(bool aMirror = true)
+        //{
+        //    mAxisMirroring.y() = aMirror ? -1 : 1;
+        //    return *this; 
+        //}
 
         math::AffineMatrix<3, GLfloat> mModelTransform;
         LoadedSprite mLoadedSprite;

--- a/src/lib/graphics/graphics/commons.h
+++ b/src/lib/graphics/graphics/commons.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <handy/Bitmask.h>
+
 #include <math/Color.h>
 
 #include <renderer/GL_Loader.h>
+
 
 namespace ad {
 namespace graphics {
@@ -24,5 +27,20 @@ struct Texture;
 struct VertexSpecification;
 
 
+enum class Mirroring
+{
+    None = 0,
+    FlipHorizontal = (1 << 1),
+    FlipVertical = (1 << 2),
+};
+
+
 } // namespace graphics
+
+
+template <>
+struct is_bitmask<graphics::Mirroring> : public std::true_type
+{};
+
+
 } // namespace ad

--- a/src/lib/graphics/graphics/shaders.h
+++ b/src/lib/graphics/graphics/shaders.h
@@ -10,11 +10,10 @@ inline const GLchar* gSpriteVertexShader = R"#(
     layout(location=0) in vec2  ve_VertexPosition;
     layout(location=1) in ivec2 ve_UV;
 
-    //layout(location=2) in mat3  in_ModelTransform;
-    layout(location=2) in vec2  in_InstancePosition;
-    layout(location=3) in ivec4 in_TextureArea;
-    layout(location=4) in float in_Opacity;
-    layout(location=5) in vec2  in_AxisMirroring;
+    layout(location=2) in mat3  in_ModelTransform;
+    layout(location=5) in ivec4 in_TextureArea;
+    layout(location=6) in float in_Opacity;
+    layout(location=7) in vec2  in_AxisMirroring;
 
     uniform vec2 u_pixelWorldSize;
     uniform mat3 u_camera;
@@ -26,8 +25,7 @@ inline const GLchar* gSpriteVertexShader = R"#(
     void main(void)
     {
         vec3 vertexPosition_local = vec3(ve_VertexPosition * in_TextureArea.zw * u_pixelWorldSize, 1.);
-        //vec3 vertexPosition_world = in_ModelTransform * vertexPosition_local;
-        vec3 vertexPosition_world = vec3(in_InstancePosition, 0.) + vertexPosition_local;
+        vec3 vertexPosition_world = in_ModelTransform * vertexPosition_local;
         vec3 vertexPosition_ndc = u_projection * u_camera * vertexPosition_world;
 
         gl_Position = vec4(vertexPosition_ndc.x, vertexPosition_ndc.y, 0., 1.);

--- a/src/lib/handy/handy/random.h
+++ b/src/lib/handy/handy/random.h
@@ -3,6 +3,7 @@
 #include <random>
 
 namespace ad {
+// TODO Use handy namespace
 
 template <class T_distribution = std::uniform_int_distribution<int>>
 struct Randomizer

--- a/src/lib/resource/resource/ResourceManager.h
+++ b/src/lib/resource/resource/ResourceManager.h
@@ -13,8 +13,10 @@ namespace ad {
 namespace resource {
 
 // TODO Make this class safer to use (currently it is very easy to get dangling references).
+// TODO Ad 2022/02/10 There should be a separate case where the loader has states 
+// (i.e. an instance is stored withing the ResourceManager data members).
 /// \attention The resources are currently hosted directly by the ResourceManager, not 
-/// inside any sharing mecanism.
+/// inside any sharing mechanism.
 /// It implies that the resource handles are only valid while the ResourceManager is alive,
 /// and while it contains them. This is currently left as the user responsibility.
 template <class T_resource, auto F_loader>


### PR DESCRIPTION
closes #40

- Use an alias for SpriteLoading return pairs.
- Use a general model transform in Spriting instances, instead of pos.
- Minor: add TODO comments.
- Make the Spriting::Instance mirroring API safer to use. Replace the explicit vector with specialized flags.
