### PR TITLE
topic/graphics#43 clear texture

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -21,7 +21,7 @@ class GraphicsConan(ConanFile):
         "build_tests": False,
         "glad:gl_version": "4.1",
         # Note: macos only provides GL_ARB_texture_storage and GL_ARB_internalformat_query
-        "glad:extensions": "GL_KHR_debug, GL_ARB_texture_storage",
+        "glad:extensions": "GL_KHR_debug, GL_ARB_texture_storage, GL_ARB_clear_texture",
     }
 
     requires = (

--- a/src/lib/graphics/graphics/detail/GlyphUtilities.h
+++ b/src/lib/graphics/graphics/detail/GlyphUtilities.h
@@ -134,7 +134,7 @@ struct DynamicGlyphCache
 
     void growAtlas()
     {
-        atlases.push_back(make_TextureRibon(ribonDimension, GL_RGB8, margins, textureFiltering));
+        atlases.push_back(make_TextureRibon(ribonDimension, GL_R8, margins, textureFiltering));
     }
 
     RenderedGlyph at(arte::CharCode aCharCode, const arte::FontFace & aFontFace);

--- a/src/lib/graphics/graphics/detail/GlyphUtilities.h
+++ b/src/lib/graphics/graphics/detail/GlyphUtilities.h
@@ -51,6 +51,8 @@ inline TextureRibon make_TextureRibon(math::Size<2, GLint> aDimensions, GLenum a
 {
     TextureRibon ribon{Texture{GL_TEXTURE_RECTANGLE}, aDimensions.width(), aMargins};
     allocateStorage(ribon.texture, aInternalFormat, aDimensions.width(), aDimensions.height());
+    // Note: Only the first (red) value will be used for a GL_R8 texture, but the API requires a 4-channel color.
+    clear(ribon.texture, {math::hdr::gBlack, 0.f});
 
     bind(ribon.texture);
     glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, aTextureFiltering);

--- a/src/lib/renderer/renderer/CMakeLists.txt
+++ b/src/lib/renderer/renderer/CMakeLists.txt
@@ -23,6 +23,8 @@ set(${TARGET_NAME}_SOURCES
     Shading.cpp
     VertexSpecification.cpp
 
+    Texture.cpp
+
     stb_image.c
 )
 

--- a/src/lib/renderer/renderer/Texture.cpp
+++ b/src/lib/renderer/renderer/Texture.cpp
@@ -1,0 +1,34 @@
+#include "Texture.h"
+
+#include "FrameBuffer.h"
+
+#include "GL_Loader.h"
+
+
+namespace ad {
+namespace graphics {
+
+void clear(const Texture & aTexture, math::hdr::Rgba aClearValue)
+{
+    std::array<GLfloat, 4> clear{
+        aClearValue.r(),
+        aClearValue.g(),
+        aClearValue.b(),
+        aClearValue.a(),
+    };
+
+    if (!GL_ARB_clear_texture)
+    {
+        FrameBuffer fb;
+        attachImage(fb, aTexture);
+        glClearBufferfv(GL_COLOR, 0, clear.data());
+    }
+    else
+    {
+        bind_guard bound(aTexture);
+        glClearTexImage(aTexture, 0, GL_RGBA, GL_FLOAT, clear.data());
+    }
+}
+
+} // namespace graphics
+} // namespace ad

--- a/src/lib/renderer/renderer/Texture.h
+++ b/src/lib/renderer/renderer/Texture.h
@@ -134,6 +134,8 @@ inline void allocateStorage(const Texture & aTexture, const GLenum aInternalForm
                            aResolution.width(), aResolution.height());
 }
 
+void clear(const Texture & aTexture, math::hdr::Rgba aClearValue);
+
 /// \brief Parameter for `writeTo()` below.
 struct InputImageParameters
 {


### PR DESCRIPTION
closes #43

- Implement clear(Texture).
- Clear DynamicRibbon texture to "transparent" when growing atlas.
- Fix: Use a single channel (GL_R8) type of texture for glyph ribbon.
