### PR TITLE
topic/60 safer scope guards

### DIFF
--- a/src/apps/prototypes/bloom/Scene.h
+++ b/src/apps/prototypes/bloom/Scene.h
@@ -117,7 +117,7 @@ Scene::Scene(const char * argv[], const AppInterface * aAppInterface) :
 
         // This list of draw buffer is part of the FBO state
         // see: https://stackoverflow.com/a/34973291/1027706
-        bind_guard bound{frameBuffer};
+        ScopedBind bound{frameBuffer};
         unsigned int attachments[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
         glDrawBuffers(2, attachments);
     }

--- a/src/libs/graphics/graphics/2d/Shaping.cpp
+++ b/src/libs/graphics/graphics/2d/Shaping.cpp
@@ -16,14 +16,14 @@ CameraProjection::CameraProjection()
         math::Matrix<4, 4, GLfloat>::Identity(),
     };
 
-    bind_guard bound{mUniformBuffer};
+    ScopedBind bound{mUniformBuffer};
     glBufferData(GL_UNIFORM_BUFFER, sizeof(identities), identities.data(), GL_DYNAMIC_DRAW);
 }
 
 
 void CameraProjection::setCameraTransformation(const math::AffineMatrix<4, GLfloat> & aTransformation)
 {
-    bind_guard bound{mUniformBuffer};
+    ScopedBind bound{mUniformBuffer};
     glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(aTransformation),
                     aTransformation.data());
 }
@@ -31,7 +31,7 @@ void CameraProjection::setCameraTransformation(const math::AffineMatrix<4, GLflo
 
 void CameraProjection::setProjectionTransformation(const math::Matrix<4, 4, GLfloat> & aTransformation)
 {
-    bind_guard bound{mUniformBuffer};
+    ScopedBind bound{mUniformBuffer};
     glBufferSubData(GL_UNIFORM_BUFFER, sizeof(aTransformation), sizeof(aTransformation),
                     aTransformation.data());
 }

--- a/src/libs/graphics/graphics/Spriting.cpp
+++ b/src/libs/graphics/graphics/Spriting.cpp
@@ -151,7 +151,7 @@ void Spriting::render(const sprite::LoadedAtlas & aAtlas) const
 {
     activate(mVertexSpecification, mProgram);
 
-    bind_guard scopedTexture{*aAtlas.texture, GL_TEXTURE0 + gTextureUnit};
+    ScopedBind scopedTexture{*aAtlas.texture, GL_TEXTURE0 + gTextureUnit};
 
     glDrawArraysInstanced(GL_TRIANGLE_STRIP,
                           0,

--- a/src/libs/graphics/graphics/Tiling.cpp
+++ b/src/libs/graphics/graphics/Tiling.cpp
@@ -198,7 +198,7 @@ void Tiling::render(const sprite::LoadedAtlas & aAtlas, const TileSet & aTileSet
     //
     // Draw
     //
-    bind_guard scopedTexture{*aAtlas.texture, GL_TEXTURE0 + gTextureUnit};
+    ScopedBind scopedTexture{*aAtlas.texture, GL_TEXTURE0 + gTextureUnit};
 
     glDrawArraysInstanced(GL_TRIANGLE_STRIP,
                           0,

--- a/src/libs/graphics/graphics/effects/Fade.cpp
+++ b/src/libs/graphics/graphics/effects/Fade.cpp
@@ -40,10 +40,10 @@ void Fade::apply(math::sdr::Rgba aFadeToColor,
     // Active the texture unit that is mapped to the programs sampler,
     // and bind the source texture.
     auto activeTexUnit = activateTextureUnitGuard(gTextureUnit);
-    bind_guard boundTexture{aSource};
+    ScopedBind boundTexture{aSource};
 
     // Bind the target.
-    bind_guard boundFrameBuffer{aTarget};
+    ScopedBind boundFrameBuffer{aTarget};
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, detail::gQuadVerticeCount);
 }

--- a/src/libs/graphics/graphics/effects/GaussianBlur.cpp
+++ b/src/libs/graphics/graphics/effects/GaussianBlur.cpp
@@ -105,9 +105,9 @@ PingPongFrameBuffers::PingPongFrameBuffers(Size2<GLsizei> aResolution, GLenum aF
 }
 
 
-[[nodiscard]] bind_guard PingPongFrameBuffers::bindTargetFrameBuffer()
+[[nodiscard]] ScopedBind PingPongFrameBuffers::bindTargetFrameBuffer()
 {
-    return bind_guard{mFrameBuffers[mTarget]};
+    return ScopedBind{mFrameBuffers[mTarget]};
 }
 
 
@@ -218,7 +218,7 @@ void GaussianBlur::apply(int aPassCount,
         // It will be 1 less if there is an explicit last render target.
         for (; step < aPassCount * mProgramSequence.size() - (aLastTarget ? 1 : 0); ++step)
         {
-            bind_guard boundFrameBuffer = aFrameBuffers.bindTargetFrameBuffer();
+            ScopedBind boundFrameBuffer = aFrameBuffers.bindTargetFrameBuffer();
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             executeStep(step);
         }
@@ -226,7 +226,7 @@ void GaussianBlur::apply(int aPassCount,
     // In case pass count is zero (or negative), we shoud not execute the program even once
     if (aLastTarget && aPassCount > 0)
     {
-        bind_guard boundFrameBuffer{**aLastTarget};
+        ScopedBind boundFrameBuffer{**aLastTarget};
         // No glClear on a client provided last buffer.
         executeStep(step+1);
     }

--- a/src/libs/graphics/graphics/effects/GaussianBlur.h
+++ b/src/libs/graphics/graphics/effects/GaussianBlur.h
@@ -42,7 +42,7 @@ struct PingPongFrameBuffers
 
     /// \brief Bind the current target framebuffer, so draw operations will affect it.
     /// \return A guard to unbind (i.e. to restore default framebuffer).
-    [[nodiscard]] bind_guard bindTargetFrameBuffer();
+    [[nodiscard]] ScopedBind bindTargetFrameBuffer();
 
     /// \brief Set the viewport to match the frame buffers resolution, and return a Guard
     /// to restore previous viewport.

--- a/src/libs/graphics/graphics/shaders.h
+++ b/src/libs/graphics/graphics/shaders.h
@@ -102,7 +102,7 @@ inline const GLchar* gTrivialColorVertexShader = R"#(
     void main(void)
     {
         gl_Position = vec4(projection * camera * vec3(in_VertexPosition, 1.), 1.);
-        ex_Color = in_VertexColor;
+        ex_Color = vec4(in_VertexColor, 1.);
     }
 )#";
 
@@ -110,12 +110,12 @@ inline const GLchar* gTrivialColorVertexShader = R"#(
 inline const GLchar* gTrivialFragmentShader = R"#(
     #version 400
 
-    in vec3 ex_Color;
+    in vec4 ex_Color;
     out vec4 out_Color;
 
     void main(void)
     {
-        out_Color = vec4(ex_Color, 1.);
+        out_Color = ex_Color;
     }
 )#";
 

--- a/src/libs/renderer/renderer/Drawing.h
+++ b/src/libs/renderer/renderer/Drawing.h
@@ -89,9 +89,29 @@ inline std::vector<VertexBufferObject> & buffers(DrawContext & aDrawContext)
 template <class T_index>
 inline Guard scopePrimitiveRestartIndex(T_index aIndex)
 {
-    glEnable(GL_PRIMITIVE_RESTART);
+    bool wasEnabled = isEnabled(GL_PRIMITIVE_RESTART);
+    // We want to restore the restart index value even if it is not enabled.
+    GLint previousIndex;
+    glGetIntegerv(GL_PRIMITIVE_RESTART_INDEX, &previousIndex);
+
     glPrimitiveRestartIndex(aIndex);
-    return Guard{ [](){glDisable(GL_PRIMITIVE_RESTART);} };
+
+    if(wasEnabled)
+    {
+        return Guard{ [previousIndex]()
+            {
+                glPrimitiveRestartIndex(previousIndex); 
+            }};
+    }
+    else
+    {
+        glEnable(GL_PRIMITIVE_RESTART);
+        return Guard{ [previousIndex]()
+            {
+                glDisable(GL_PRIMITIVE_RESTART);
+                glPrimitiveRestartIndex(previousIndex);
+            }};
+    }
 }
 
 

--- a/src/libs/renderer/renderer/FrameBuffer.h
+++ b/src/libs/renderer/renderer/FrameBuffer.h
@@ -36,11 +36,46 @@ inline void bind(const FrameBuffer & aFrameBuffer)
     glBindFramebuffer(GL_FRAMEBUFFER, aFrameBuffer);
 }
 
+
 inline void unbind(const FrameBuffer & aFrameBuffer)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
+
+enum class FramebufferTarget
+{
+    Draw,
+    Read,
+};
+
+inline GLenum getBound(const FrameBuffer &, FramebufferTarget aTarget)
+{
+    GLint current;
+    switch(aTarget)
+    {
+    case FramebufferTarget::Draw:
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &current);
+        break;
+    case FramebufferTarget::Read:
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &current);
+        break;
+    }
+    return current;
+}
+
+
+template <>
+inline ScopedBind::ScopedBind(const FrameBuffer & aResource) :
+    mGuard{[previousRead = getBound(aResource, FramebufferTarget::Read),
+            previousDraw = getBound(aResource, FramebufferTarget::Draw)]()
+           {
+               glBindFramebuffer(GL_DRAW_FRAMEBUFFER, previousDraw);
+               glBindFramebuffer(GL_READ_FRAMEBUFFER, previousRead);
+           }}
+{
+    bind(aResource);
+}
 
 // make a system to attach a render image (with depth?)
 inline void attachImage(
@@ -49,7 +84,7 @@ inline void attachImage(
         GLenum aAttachment=GL_COLOR_ATTACHMENT0,
         GLint aTextureLayer=0)
 {
-    bind_guard bound{aFrameBuffer};
+    ScopedBind bound{aFrameBuffer};
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, aAttachment, aTexture.mTarget, aTexture, aTextureLayer);
 
     // TODO completeness check should not occur after each attachment

--- a/src/libs/renderer/renderer/MappedGL.h
+++ b/src/libs/renderer/renderer/MappedGL.h
@@ -46,6 +46,40 @@ constexpr GLenum MappedPixel_v = MappedPixel<T_pixel>::enumerator;
 #undef MAP
 
 
+//
+// glGet parameter names for texture bindings
+//
+template <GLenum N_textureTarget>
+struct MappedTextureBindingGL;
+
+#define TEXTURECASE(textureTarget, paramName)   \
+    case textureTarget:                         \
+        return paramName;
+
+
+constexpr GLenum getGLMappedTextureBinding(GLenum aTextureTarget) 
+{
+    switch(aTextureTarget)
+    {
+        TEXTURECASE(GL_TEXTURE_1D, GL_TEXTURE_BINDING_1D);
+        TEXTURECASE(GL_TEXTURE_1D_ARRAY, GL_TEXTURE_BINDING_1D_ARRAY);
+        TEXTURECASE(GL_TEXTURE_2D, GL_TEXTURE_BINDING_2D);
+        TEXTURECASE(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_BINDING_2D_ARRAY);
+        TEXTURECASE(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_BINDING_2D_MULTISAMPLE);
+        TEXTURECASE(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY);
+        TEXTURECASE(GL_TEXTURE_3D, GL_TEXTURE_BINDING_3D);
+        TEXTURECASE(GL_TEXTURE_BUFFER, GL_TEXTURE_BINDING_BUFFER);
+        TEXTURECASE(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_BINDING_CUBE_MAP);
+        TEXTURECASE(GL_TEXTURE_RECTANGLE, GL_TEXTURE_BINDING_RECTANGLE);
+    default:
+        throw std::domain_error{"Invalid texture target."};
+    }
+}
+
+
+#undef TEXTURECASE
+
+
 enum class BufferHint
 {
     StreamDraw,

--- a/src/libs/renderer/renderer/Texture.cpp
+++ b/src/libs/renderer/renderer/Texture.cpp
@@ -18,7 +18,7 @@ void clear(const Texture & aTexture, math::hdr::Rgba_f aClearValue)
     }
     else
     {
-        bind_guard bound(aTexture);
+        ScopedBind bound(aTexture);
         glClearTexImage(aTexture, 0, GL_RGBA, GL_FLOAT, aClearValue.data());
     }
 }

--- a/src/libs/renderer/renderer/UniformBuffer.h
+++ b/src/libs/renderer/renderer/UniformBuffer.h
@@ -32,5 +32,22 @@ inline void unbind(const UniformBufferObject &)
 }
 
 
+inline GLenum getBound(const UniformBufferObject &)
+{
+    GLint current;
+    glGetIntegerv(GL_UNIFORM_BUFFER_BINDING, &current);
+    return current;
+}
+
+
+template <>
+inline ScopedBind::ScopedBind(const UniformBufferObject & aResource) :
+    mGuard{[previous = getBound(aResource)]
+           { glBindBuffer(GL_UNIFORM_BUFFER_BINDING, previous);}}
+{
+    bind(aResource);
+}
+
+
 } // namespace graphics
 } // namespace ad

--- a/src/libs/renderer/renderer/gl_helpers.h
+++ b/src/libs/renderer/renderer/gl_helpers.h
@@ -28,15 +28,18 @@ inline GLuint reserve(void(GLAPIENTRY * aGlGenFunction)(GLsizei, GLuint *))
     return name;
 }
 
-class bind_guard
+class ScopedBind
 {
 public:
     template <class T_resource, class... VT_args>
-    bind_guard(const T_resource & aResource, VT_args &&... aArgs) :
-        mGuard{[&aResource](){ unbind(aResource); }}
-    {
-        bind(aResource, std::forward<VT_args>(aArgs)...);
-    }
+    ScopedBind(const T_resource & aResource, VT_args &&... aArgs);
+    // TODO Make the generic implementation work.
+    // The problem is with the bind in the guard, as it expects a wrapped type.
+    //:
+    //    mGuard{[previous = getBound(aResource)](){ bind(previous); }}
+    //{
+    //    bind(aResource, std::forward<VT_args>(aArgs)...);
+    //}
 
 private:
     Guard mGuard;


### PR DESCRIPTION
closes #60

- Fix trivial linestrip shaders.
- Restore previous state in all scope guards of renderer lib.
