### PR TITLE
topic/graphics#69 dynamic program binding

### DIFF
--- a/.github/workflows/develop-build_test_deployrecipe.yml
+++ b/.github/workflows/develop-build_test_deployrecipe.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-test-deployrecipe:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.4.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.4.2
     with:
       # Disable macos while spdlog crashes its compiler
       # see: https://github.com/conan-io/conan-center-index/issues/8480

--- a/.github/workflows/topics-build_test.yml
+++ b/.github/workflows/topics-build_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-test:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.4.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.4.2
     with:
       # Disable macos while spdlog crashes its compiler
       # see: https://github.com/conan-io/conan-center-index/issues/8480

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ cmc_include_conan_configuration()
 # Enable the grouping target in folders, when available in IDE.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# Export compile commands by default
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-
 # Install the top-level package config, allowing to find all sub-components
 include(cmc-install)
 cmc_install_root_component_config(${PROJECT_NAME})

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -35,7 +35,7 @@ class GraphicsConan(ConanFile):
         ("glad/0.1.36"),
         ("glfw/3.3.8@adnn/patch"),
         ("nlohmann_json/3.9.1"),
-        ("spdlog/1.10.0"),
+        ("spdlog/1.11.0"),
         ("utfcpp/3.2.1"),
         ("imgui/1.88"),
 

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,7 +23,11 @@ class GraphicsConan(ConanFile):
         "build_tests": False,
         "glad:gl_version": "4.1",
         # Note: macos only provides GL_ARB_texture_storage and GL_ARB_internalformat_query
-        "glad:extensions": "GL_KHR_debug, GL_ARB_texture_storage, GL_ARB_clear_texture",
+        "glad:extensions": ("GL_KHR_debug,"
+            "GL_ARB_texture_storage,"
+            "GL_ARB_clear_texture,"
+            "GL_ARB_program_interface_query,"
+            "GL_ARB_shader_storage_buffer_object,")
     }
 
     requires = (

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -39,8 +39,8 @@ class GraphicsConan(ConanFile):
         ("utfcpp/3.2.1"),
         ("imgui/1.88"),
 
-        ("handy/9cea48868d@adnn/develop"),
-        ("math/541fce5f6a@adnn/develop"),
+        ("handy/bb2bf93c7e@adnn/develop"),
+        ("math/b2d72655a8@adnn/develop"),
     )
 
     build_policy = "missing"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ if(BUILD_tests)
     add_subdirectory(apps/prototypes/polyline)
     add_subdirectory(apps/prototypes/curve)
     add_subdirectory(apps/prototypes/font)
+    add_subdirectory(apps/prototypes/shader_introspection)
 
     add_subdirectory(apps/samples/trivial_linestr/trivial_linestr)
     add_subdirectory(apps/samples/trivial_shaping/trivial_shaping)

--- a/src/apps/graphics_tests/graphics_tests/CMakeLists.txt
+++ b/src/apps/graphics_tests/graphics_tests/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(${TARGET_NAME}
         ad::test_commons
         )
 
+cmc_cpp_all_warnings_as_errors(${TARGET_NAME} ENABLED ${BUILD_CONF_WarningAsError})
+
+cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
+
 set_target_properties(${TARGET_NAME} PROPERTIES
                       VERSION "${${PROJECT_NAME}_VERSION}"
 )

--- a/src/apps/prototypes/curve/Scene.h
+++ b/src/apps/prototypes/curve/Scene.h
@@ -162,7 +162,7 @@ inline Scene::Scene() :
 
 inline void Scene::step(const Timer & aTimer)
 {
-    setUniformFloat(mGenerativeProgram, "halfWidth", 0.1f);
+    setUniform(mGenerativeProgram, "halfWidth", 0.1f);
     respecifyBuffer(mGenerativeVertexSpecification.mVertexBuffers[1],
                     std::span{mBezier.p});
 }

--- a/src/apps/prototypes/font/Scene.h
+++ b/src/apps/prototypes/font/Scene.h
@@ -135,10 +135,10 @@ inline Scene::Scene(const filesystem::path & aFontPath,
         initVertexBuffer<GlyphInstance>(mGlyphQuadVertex.mVertexArray, gGlyphInstanceDescription, 1));
 
     // Screen program
-    setUniformInt(mPassthrough, "inputTexture", gTextureUnit);
+    setUniform(mPassthrough, "inputTexture", gTextureUnit);
 
     // Font program
-    setUniformInt(mFontProgram, "inputTexture", gTextureUnit);
+    setUniform(mFontProgram, "inputTexture", gTextureUnit);
     setUniform(mFontProgram, "u_PixelToWorld", mPixelToWorld);
     setUniform(mFontProgram, "u_WorldToCamera", math::AffineMatrix<4, GLfloat>::Identity());
     setUniform(mFontProgram, "u_Projection", 
@@ -149,7 +149,7 @@ inline Scene::Scene(const filesystem::path & aFontPath,
     // Font atlas generation
     auto startingCharcode = gStartingCharcode;
     GLsizei textureWidth = gGlyphPerLine * (aGlyphPixelHeight + gHorizontalMargin);
-    // Add 1 in height, for example character 253 'ý' from DejaVuSans
+    // Add 1 in height, for example character 253 'ï¿½' from DejaVuSans
     // has 129 rows when the pixel height is set to 128...
     allocateStorage(mFontAtlas, GL_R8, textureWidth, aGlyphPixelHeight + 1);
     bind(mFontAtlas);

--- a/src/apps/prototypes/polyline/Scene.h
+++ b/src/apps/prototypes/polyline/Scene.h
@@ -16,7 +16,7 @@
 
 
 // The approach is to draw miter joints with the minimal number of vertices.
-// A geometry shader is used to find the miter vector, 
+// A geometry shader is used to find the miter vector,
 // then place the corner vertices at the correct distance along miter vector.
 // see: https://en.sfml-dev.org/forums/index.php?topic=21620.msg153681#msg153681
 // It is compared to the naive approach with overdraw and discontinuities.
@@ -81,8 +81,9 @@ inline Scene::Scene() :
 
 inline void Scene::step(const Timer & aTimer)
 {
-    setUniform(mProgramNaive, "lineHalfWidth", 0.05f + 0.04f * std::cosf(aTimer.time()));
-    setUniform(mProgramMiter, "lineHalfWidth", 0.05f + 0.04f * std::cosf(aTimer.time()));
+    // Note: cosf is not currently available in GNU's lib (see bug #79700)
+    setUniform(mProgramNaive, "lineHalfWidth", 0.05f + 0.04f * std::cos((float)aTimer.time()));
+    setUniform(mProgramMiter, "lineHalfWidth", 0.05f + 0.04f * std::cos((float)aTimer.time()));
 }
 
 

--- a/src/apps/prototypes/polyline/Scene.h
+++ b/src/apps/prototypes/polyline/Scene.h
@@ -12,6 +12,8 @@
 #include <math/Vector.h>
 #include <math/VectorUtilities.h>
 
+#include <cmath>
+
 
 // The approach is to draw miter joints with the minimal number of vertices.
 // A geometry shader is used to find the miter vector, 

--- a/src/apps/prototypes/polyline/Scene.h
+++ b/src/apps/prototypes/polyline/Scene.h
@@ -79,8 +79,8 @@ inline Scene::Scene() :
 
 inline void Scene::step(const Timer & aTimer)
 {
-    setUniformFloat(mProgramNaive, "lineHalfWidth", 0.05f + 0.04f * std::cos(aTimer.time()));
-    setUniformFloat(mProgramMiter, "lineHalfWidth", 0.05f + 0.04f * std::cos(aTimer.time()));
+    setUniform(mProgramNaive, "lineHalfWidth", 0.05f + 0.04f * std::cosf(aTimer.time()));
+    setUniform(mProgramMiter, "lineHalfWidth", 0.05f + 0.04f * std::cosf(aTimer.time()));
 }
 
 

--- a/src/apps/prototypes/shader_introspection/CMakeLists.txt
+++ b/src/apps/prototypes/shader_introspection/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(TARGET_NAME shader_introspection)
+
+set(${TARGET_NAME}_HEADERS
+    Introspection.h
+)
+
+set(${TARGET_NAME}_SOURCES
+    main.cpp
+)
+
+add_executable(${TARGET_NAME}
+    ${${TARGET_NAME}_SOURCES}
+    ${${TARGET_NAME}_HEADERS}
+)
+
+target_link_libraries(${TARGET_NAME}
+    PRIVATE
+        graphics
+        renderer
+)
+
+set_target_properties(${TARGET_NAME} PROPERTIES FOLDER prototypes)

--- a/src/apps/prototypes/shader_introspection/Introspection.h
+++ b/src/apps/prototypes/shader_introspection/Introspection.h
@@ -1,0 +1,175 @@
+#include <renderer/GL_Loader.h>
+#include <renderer/Shading.h>
+
+#include <cassert>
+
+
+namespace ad {
+
+
+inline void inspectProgram(const graphics::Program & aProgram)
+{
+    if(GLAD_GL_ARB_program_interface_query)
+    {
+        GLint resourceCount;
+        GLint maxNameLength;
+
+        //
+        // Vertex Attributes
+        //
+        GLenum programInterface = GL_PROGRAM_INPUT;
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_ACTIVE_RESOURCES, &resourceCount);
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_MAX_NAME_LENGTH, &maxNameLength);
+
+        auto iterate = [&](const std::string & aCategory)
+        {
+            auto nameBuffer = std::make_unique<char[]>(maxNameLength);
+            for(GLuint resourceId = 0; resourceId != resourceCount; ++resourceId)
+            {
+                const GLenum properties[] = {
+                    GL_NAME_LENGTH, // The result is actually unused if we use the shared namedBuffer
+                    GL_TYPE,
+                    GL_LOCATION,
+                    //GL_BLOCK_INDEX, // Index of the active interface block containing, -1 if not part of any.
+                };
+                GLint params[std::size(properties)];
+                GLint length;
+
+                glGetProgramResourceiv(aProgram, programInterface, resourceId,
+                                       (GLsizei)std::size(properties), properties,
+                                       (GLsizei)std::size(params), &length, params);
+
+                //// The returned length makes provision for a terminating null character.
+                //std::string attributeName(params[0], '\0');
+                //// This does write a null character at the end.
+                //glGetProgramResourceName(aProgram, programInterface, resourceId,
+                //                        (GLsizei)std::size(attributeName), &params[0], attributeName.data());
+                glGetProgramResourceName(aProgram, programInterface, resourceId,
+                                         maxNameLength, &params[0], nameBuffer.get());
+                // WARNING: glGetProgramResource() returned the length **including** null terminator,
+                //          whereas glGetProgramResourceName() returns the length **excluding** null terminator.
+                // No need to substract 1 from the length, as it does not include null terminator.
+                std::string attributeName(nameBuffer.get(), params[0]);
+
+                // (Notably) uniforms within uniform blocks are getting -1 as location,
+                // use it as a q&d filter.
+                if (params[2] != -1)
+                {
+                    std::cout << aCategory << " " << attributeName 
+                        << " at location " << params[2]
+                        << " has type " << params[1] 
+                        << "." << std::endl;
+                }
+            }
+        };
+        iterate("Attribute");
+
+        //
+        // Uniforms
+        //
+        programInterface = GL_UNIFORM;
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_ACTIVE_RESOURCES, &resourceCount);
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_MAX_NAME_LENGTH, &maxNameLength);
+
+        iterate("Uniform");
+
+        //
+        // Uniform blocks
+        //
+        programInterface = GL_UNIFORM_BLOCK;
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_ACTIVE_RESOURCES, &resourceCount);
+        glGetProgramInterfaceiv(aProgram, programInterface, GL_MAX_NAME_LENGTH, &maxNameLength);
+
+        auto blockIterate = [&](const std::string & aCategory, GLenum aVariableInterface)
+        {
+            auto nameBuffer = std::make_unique<char[]>(maxNameLength);
+            for(GLuint blockId = 0; blockId != resourceCount; ++blockId)
+            {
+                const GLenum properties[] = {
+                    GL_NAME_LENGTH, // The result is actually unused if we use the shared namedBuffer
+                    GL_BUFFER_BINDING,
+                    GL_NUM_ACTIVE_VARIABLES,
+                };
+                GLint params[std::size(properties)];
+                GLint length;
+
+                glGetProgramResourceiv(aProgram, programInterface, blockId,
+                                       (GLsizei)std::size(properties), properties,
+                                       (GLsizei)std::size(params), &length, params);
+
+                glGetProgramResourceName(aProgram, programInterface, blockId,
+                                         maxNameLength, &params[0], nameBuffer.get());
+                // WARNING: glGetProgramResource() returned the length **including** null terminator,
+                //          whereas glGetProgramResourceName() returns the length **excluding** null terminator.
+                // No need to substract 1 from the length, as it does not include null terminator.
+                std::string blockName(nameBuffer.get(), params[0]);
+
+                std::cout << aCategory << " " << blockName 
+                    << " at binding index " << params[1]
+                    << " has " << params[2] << " active variables"
+                    << "." << std::endl;
+
+                //
+                // Get the variables composing this interface block
+                //
+                const GLenum variableProperty[] = {
+                    GL_ACTIVE_VARIABLES, // array of active variables indices
+                };
+                std::vector<GLint> variableIds(params[2]);
+
+                glGetProgramResourceiv(aProgram, programInterface, blockId,
+                                       (GLsizei)std::size(variableProperty), variableProperty,
+                                       (GLsizei)std::size(variableIds), &length, variableIds.data());
+                assert(length == params[2]);
+
+                for(GLint variableId : variableIds)
+                {
+                    const GLenum properties[] = {
+                        GL_NAME_LENGTH, // The result is actually unused if we use the shared namedBuffer
+                        GL_TYPE,
+                        GL_BLOCK_INDEX,
+                        //GL_LOCATION, // should be -1 for uniforms in uniform blocks,
+                                       // but is not available for shader storabe blocks' variables
+                    };
+                    GLint params[std::size(properties)];
+                    GLint length;
+
+                    glGetProgramResourceiv(aProgram, aVariableInterface, variableId,
+                                           (GLsizei)std::size(properties), properties,
+                                           (GLsizei)std::size(params), &length, params);
+
+                    std::vector<char> nameBuffer(params[0]);
+                    glGetProgramResourceName(aProgram, aVariableInterface, variableId,
+                                             (GLsizei)std::size(nameBuffer), &params[0], nameBuffer.data());
+                    // WARNING: glGetProgramResource() returned the length **including** null terminator,
+                    //          whereas glGetProgramResourceName() returns the length **excluding** null terminator.
+                    // No need to substract 1 from the length, as it does not include null terminator.
+                    std::string variableName(nameBuffer.data(), params[0]);
+
+                    assert(params[2] == blockId);
+                    //assert(params[3] == -1);
+                    std::cout << "\t* " << variableName 
+                        << " has type " << params[1]
+                        << "." << std::endl;
+                }
+            }
+        };
+
+        blockIterate("Uniform block", GL_UNIFORM);
+
+        //
+        // Shader storage blocks
+        //
+        if (GLAD_GL_ARB_shader_storage_buffer_object)
+        {
+            programInterface = GL_SHADER_STORAGE_BLOCK;
+            glGetProgramInterfaceiv(aProgram, programInterface, GL_ACTIVE_RESOURCES, &resourceCount);
+            glGetProgramInterfaceiv(aProgram, programInterface, GL_MAX_NAME_LENGTH, &maxNameLength);
+
+            blockIterate("Shader storage block", GL_BUFFER_VARIABLE);
+        }
+    }
+}
+
+
+} // namespace ad

--- a/src/apps/prototypes/shader_introspection/Introspection.h
+++ b/src/apps/prototypes/shader_introspection/Introspection.h
@@ -1,6 +1,8 @@
 #include <renderer/GL_Loader.h>
 #include <renderer/Shading.h>
 
+#include <memory>
+
 #include <cassert>
 
 
@@ -55,9 +57,9 @@ inline void inspectProgram(const graphics::Program & aProgram)
                 // use it as a q&d filter.
                 if (params[2] != -1)
                 {
-                    std::cout << aCategory << " " << attributeName 
+                    std::cout << aCategory << " " << attributeName
                         << " at location " << params[2]
-                        << " has type " << params[1] 
+                        << " has type " << params[1]
                         << "." << std::endl;
                 }
             }
@@ -105,7 +107,7 @@ inline void inspectProgram(const graphics::Program & aProgram)
                 // No need to substract 1 from the length, as it does not include null terminator.
                 std::string blockName(nameBuffer.get(), params[0]);
 
-                std::cout << aCategory << " " << blockName 
+                std::cout << aCategory << " " << blockName
                     << " (block index: " << blockId << ")"
                     << " at binding index " << params[1]
                     << " has " << params[2] << " active variables"
@@ -150,7 +152,7 @@ inline void inspectProgram(const graphics::Program & aProgram)
 
                     assert(params[2] == blockId);
                     //assert(params[3] == -1);
-                    std::cout << "\t* " << variableName 
+                    std::cout << "\t* " << variableName
                         << " has type " << params[1]
                         << "." << std::endl;
                 }

--- a/src/apps/prototypes/shader_introspection/Introspection.h
+++ b/src/apps/prototypes/shader_introspection/Introspection.h
@@ -83,6 +83,7 @@ inline void inspectProgram(const graphics::Program & aProgram)
         auto blockIterate = [&](const std::string & aCategory, GLenum aVariableInterface)
         {
             auto nameBuffer = std::make_unique<char[]>(maxNameLength);
+            // Note: I suppose blockId is the block index returned from glGetUniformBlockIndex()
             for(GLuint blockId = 0; blockId != resourceCount; ++blockId)
             {
                 const GLenum properties[] = {
@@ -105,6 +106,7 @@ inline void inspectProgram(const graphics::Program & aProgram)
                 std::string blockName(nameBuffer.get(), params[0]);
 
                 std::cout << aCategory << " " << blockName 
+                    << " (block index: " << blockId << ")"
                     << " at binding index " << params[1]
                     << " has " << params[2] << " active variables"
                     << "." << std::endl;

--- a/src/apps/prototypes/shader_introspection/main.cpp
+++ b/src/apps/prototypes/shader_introspection/main.cpp
@@ -1,0 +1,108 @@
+#include "Introspection.h"
+
+#include <graphics/ApplicationGlfw.h>
+#include <renderer/Shading.h>
+
+
+using namespace ad;
+
+
+//
+// Some basic implementation of Phong illumination model.
+// Serving as a candidate for introspection.
+//
+inline const GLchar* gVertexShader = R"#(
+#version 430
+
+layout(location=0) in vec3 ve_VertexPosition_l;
+layout(location=1) in vec3 ve_Normal_l;
+
+layout(location=4) in mat4 in_LocalToWorld;
+layout(location=8) in mat4 in_LocalToWorldInverseTranspose;
+in vec4 in_Albedo; // no explicit location
+
+layout(std140) uniform ViewingBlock
+{
+    mat4 u_Camera;
+    mat4 u_Projection;
+};
+
+layout(std140) buffer Gratuitous
+{
+    ivec2 u_MyVecTwoInt;
+    float u_MyFloat;
+};
+
+out vec4 ex_Position_v;
+out vec4 ex_Normal_v;
+out vec3 ex_DiffuseColor;
+out vec3 ex_SpecularColor;
+out float ex_Opacity;
+
+void main(void)
+{
+    mat4 localToCamera = u_Camera * in_LocalToWorld;
+    ex_Position_v = localToCamera * vec4(ve_VertexPosition_l, 1.f);
+    gl_Position = u_Projection * ex_Position_v;
+    ex_Normal_v = localToCamera * vec4(ve_Normal_l, 0.f);
+
+    ex_DiffuseColor  = in_Albedo.rgb;
+    ex_SpecularColor = in_Albedo.rgb;
+    ex_Opacity       = in_Albedo.a;
+}
+)#";
+
+
+inline const GLchar* gFragmentShader = R"#(
+#version 430
+
+in vec4 ex_Position_v;
+in vec4 ex_Normal_v;
+in vec3 ex_DiffuseColor;
+in vec3  ex_SpecularColor;
+in float ex_Opacity;
+
+uniform vec3 u_LightPosition_v;
+uniform vec3 u_LightColor;
+uniform vec3 u_AmbientColor;
+
+out vec4 out_Color;
+
+void main(void)
+{
+    // Everything in camera space
+    vec3 light = normalize(u_LightPosition_v - ex_Position_v.xyz);
+    vec3 view = vec3(0., 0., 1.);
+    vec3 h = normalize(view + light);
+    vec3 normal = normalize(ex_Normal_v.xyz); // cannot normalize in vertex shader, as interpolation changes length.
+    
+    float specularExponent = 32;
+
+    vec3 diffuse = 
+        ex_DiffuseColor * (u_AmbientColor + u_LightColor * max(0.f, dot(normal, light)));
+    vec3 specular = 
+        u_LightColor * ex_SpecularColor * pow(max(0.f, dot(normal, h)), specularExponent);
+    vec3 color = diffuse + specular;
+
+    // Gamma correction
+    float gamma = 2.2;
+    out_Color = vec4(pow(color, vec3(1./gamma)), ex_Opacity);
+}
+)#";
+
+
+
+int main(void)
+{
+    // Solely to get an OpenGL context
+    graphics::ApplicationGlfw app{"dummy", {1, 1}};
+
+    graphics::Program program{graphics::makeLinkedProgram({
+        {GL_VERTEX_SHADER,   {gVertexShader, "PhongVertexShader"}},
+        {GL_FRAGMENT_SHADER, {gFragmentShader, "PhongFragmentShader"}},
+    })};
+
+    inspectProgram(program);
+
+    std::exit(EXIT_SUCCESS);
+}

--- a/src/libs/graphics/graphics/AppInterface.cpp
+++ b/src/libs/graphics/graphics/AppInterface.cpp
@@ -171,7 +171,14 @@ void GLAPIENTRY AppInterface::OpenGLMessageLogging(GLenum source,
         }
         default:
         {
-            ADLOG(gOpenglLogger, debug)(oss.str());
+            if(severity == GL_DEBUG_SEVERITY_NOTIFICATION)
+            {
+                ADLOG(gOpenglLogger, trace)(oss.str());
+            }
+            else
+            {
+                ADLOG(gOpenglLogger, debug)(oss.str());
+            }
             break;
         }
     }

--- a/src/libs/graphics/graphics/Curving.cpp
+++ b/src/libs/graphics/graphics/Curving.cpp
@@ -35,6 +35,7 @@ namespace {
         { 5, {3, offsetof(Inst, bezier) + 3 * sizeof(Inst::Position_t), MappedGL<GLfloat>::enumerator}},
         { 6, {1, offsetof(Inst, startHalfWidth), MappedGL<GLfloat>::enumerator}},
         { 7, {1, offsetof(Inst,   endHalfWidth), MappedGL<GLfloat>::enumerator}},
+        // Manual specification of a matrix over several attributes
         { 8, {4, offsetof(Inst, modelTransform) +  0 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
         { 9, {4, offsetof(Inst, modelTransform) +  4 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
         {10, {4, offsetof(Inst, modelTransform) +  8 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},

--- a/src/libs/graphics/graphics/DrawLine.cpp
+++ b/src/libs/graphics/graphics/DrawLine.cpp
@@ -40,10 +40,10 @@ namespace
     // Per instance data
     //
     constexpr AttributeDescriptionList gInstanceDescription{
-        { 1,                                        {3, offsetof(DrawLine::Line, mOrigin),       MappedGL<GLfloat>::enumerator}},
-        { 2,                                        {3, offsetof(DrawLine::Line, mEnd),          MappedGL<GLfloat>::enumerator}},
-        { 3,                                        {1, offsetof(DrawLine::Line, mWidth_screen), MappedGL<GLfloat>::enumerator}},
-        {{4, ShaderParameter::Access::Float, true}, {4, offsetof(DrawLine::Line, mColor),        MappedGL<GLubyte>::enumerator}},
+        { 1,        {3, offsetof(DrawLine::Line, mOrigin),       MappedGL<GLfloat>::enumerator}},
+        { 2,        {3, offsetof(DrawLine::Line, mEnd),          MappedGL<GLfloat>::enumerator}},
+        { 3,        {1, offsetof(DrawLine::Line, mWidth_screen), MappedGL<GLfloat>::enumerator}},
+        {{4, true}, {4, offsetof(DrawLine::Line, mColor),        MappedGL<GLubyte>::enumerator}},
     };
 
     VertexSpecification make_VertexSpecification()

--- a/src/libs/graphics/graphics/Texting.cpp
+++ b/src/libs/graphics/graphics/Texting.cpp
@@ -64,7 +64,7 @@ Texting::Texting(const filesystem::path & aFontPath,
     mPixelToWorld = {pixelToWorld, pixelToWorld};
     setUniform(mGpuProgram, "u_PixelToWorld", mPixelToWorld);
 
-    setUniformInt(mGpuProgram, "u_FontAtlas", gTextureUnit);
+    setUniform(mGpuProgram, "u_FontAtlas", gTextureUnit);
 
     // use recommended ribon margins
     auto ribonMargins = detail::TextureRibon::gRecommendedMargins;

--- a/src/libs/graphics/graphics/Texting.cpp
+++ b/src/libs/graphics/graphics/Texting.cpp
@@ -15,11 +15,11 @@ namespace graphics {
 
 
 constexpr AttributeDescriptionList gGlyphInstanceDescription{
-    { 2,                                         {2, offsetof(Texting::Instance, position_w),    MappedGL<GLfloat>::enumerator}},
-    { {3, ShaderParameter::Access::Integer},     {1, offsetof(Texting::Instance, offsetInTexture_p), MappedGL<GLint>::enumerator}},
-    { 4,                                         {2, offsetof(Texting::Instance, boundingBox_p), MappedGL<GLfloat>::enumerator}},
-    { 5,                                         {2, offsetof(Texting::Instance, bearing_p),     MappedGL<GLfloat>::enumerator}},
-    { {6, ShaderParameter::Access::Float, true}, {4, offsetof(Texting::Instance, color), MappedGL<GLubyte>::enumerator}},
+    { 2,                                     {2, offsetof(Texting::Instance, position_w),    MappedGL<GLfloat>::enumerator}},
+    { {3, ShaderParameter::Access::Integer}, {1, offsetof(Texting::Instance, offsetInTexture_p), MappedGL<GLint>::enumerator}},
+    { 4,                                     {2, offsetof(Texting::Instance, boundingBox_p), MappedGL<GLfloat>::enumerator}},
+    { 5,                                     {2, offsetof(Texting::Instance, bearing_p),     MappedGL<GLfloat>::enumerator}},
+    { {6, true},                             {4, offsetof(Texting::Instance, color), MappedGL<GLubyte>::enumerator}},
 };
 
 

--- a/src/libs/graphics/graphics/TrivialLineStrip.cpp
+++ b/src/libs/graphics/graphics/TrivialLineStrip.cpp
@@ -21,8 +21,8 @@ namespace
     // Per vertex data
     //
     constexpr AttributeDescriptionList gVertexDescription{
-        { 0,                                        {2, offsetof(LinePoint, mPosition), MappedGL<GLfloat>::enumerator}},
-        {{1, ShaderParameter::Access::Float, true}, {3, offsetof(LinePoint, mColor),    MappedGL<GLubyte>::enumerator}},
+        { 0,        {2, offsetof(LinePoint, mPosition), MappedGL<GLfloat>::enumerator}},
+        {{1, true}, {3, offsetof(LinePoint, mColor),    MappedGL<GLubyte>::enumerator}},
     };
 
     VertexSpecification make_VertexSpecification()

--- a/src/libs/graphics/graphics/TrivialPolygon.cpp
+++ b/src/libs/graphics/graphics/TrivialPolygon.cpp
@@ -21,11 +21,11 @@ namespace
     // Per vertex data
     //
     constexpr AttributeDescriptionList gVertexDescription{
-        { 0,                                        {2, offsetof(PolygonPoint, mPosition), MappedGL<GLfloat>::enumerator}},
-        {{1, ShaderParameter::Access::Float, true}, {3, offsetof(PolygonPoint, mColor),    MappedGL<GLubyte>::enumerator}},
-        { 3,                                        {3, offsetof(PolygonPoint, mMatrixTransform), MappedGL<GLfloat>::enumerator}},
-        { 4,                                        {3, offsetof(PolygonPoint, mMatrixTransform) + 3 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
-        { 5,                                        {3, offsetof(PolygonPoint, mMatrixTransform) + 6 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
+        { 0,        {2, offsetof(PolygonPoint, mPosition), MappedGL<GLfloat>::enumerator}},
+        {{1, true}, {3, offsetof(PolygonPoint, mColor),    MappedGL<GLubyte>::enumerator}},
+        { 3,        {3, offsetof(PolygonPoint, mMatrixTransform), MappedGL<GLfloat>::enumerator}},
+        { 4,        {3, offsetof(PolygonPoint, mMatrixTransform) + 3 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
+        { 5,        {3, offsetof(PolygonPoint, mMatrixTransform) + 6 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
     };
 
     VertexSpecification make_VertexSpecification()

--- a/src/libs/graphics/graphics/TrivialShaping.cpp
+++ b/src/libs/graphics/graphics/TrivialShaping.cpp
@@ -13,7 +13,7 @@ namespace ad {
 namespace graphics {
 
 
-namespace 
+namespace
 {
 
     //
@@ -40,12 +40,10 @@ namespace
     // Per instance data
     //
     constexpr AttributeDescriptionList gInstanceDescription{
-        { 1,                                        {2, offsetof(TrivialShaping::Rectangle, mGeometry.mPosition),  MappedGL<GLfloat>::enumerator}},
-        { 2,                                        {2, offsetof(TrivialShaping::Rectangle, mGeometry.mDimension), MappedGL<GLfloat>::enumerator}},
-        { 3,                                        {3, offsetof(TrivialShaping::Rectangle, mMatrixTransform), MappedGL<GLfloat>::enumerator}},
-        { 4,                                        {3, offsetof(TrivialShaping::Rectangle, mMatrixTransform) + 3 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
-        { 5,                                        {3, offsetof(TrivialShaping::Rectangle, mMatrixTransform) + 6 * sizeof(GLfloat), MappedGL<GLfloat>::enumerator}},
-        {{6, ShaderParameter::Access::Float, true}, {4, offsetof(TrivialShaping::Rectangle, mColor),               MappedGL<GLubyte>::enumerator}},
+        { 1,                                        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mPosition),  MappedGL<GLfloat>::enumerator}},
+        { 2,                                        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mDimension), MappedGL<GLfloat>::enumerator}},
+        { 3,                                        {{3, 3}, offsetof(TrivialShaping::Rectangle, mMatrixTransform),     MappedGL<GLfloat>::enumerator}},
+        {{6, ShaderParameter::Access::Float, true}, {4,      offsetof(TrivialShaping::Rectangle, mColor),               MappedGL<GLubyte>::enumerator}},
     };
 
     VertexSpecification make_VertexSpecification()
@@ -119,13 +117,13 @@ void TrivialShaping::render() const
 
 void TrivialShaping::setCameraTransformation(const math::AffineMatrix<3, GLfloat> & aTransformation)
 {
-    setUniform(mDrawContext.mProgram, "u_camera", aTransformation); 
+    setUniform(mDrawContext.mProgram, "u_camera", aTransformation);
 }
 
 
 void TrivialShaping::setProjectionTransformation(const math::Matrix<3, 3, GLfloat> & aTransformation)
 {
-    setUniform(mDrawContext.mProgram, "u_projection", aTransformation); 
+    setUniform(mDrawContext.mProgram, "u_projection", aTransformation);
 }
 
 

--- a/src/libs/graphics/graphics/TrivialShaping.cpp
+++ b/src/libs/graphics/graphics/TrivialShaping.cpp
@@ -40,10 +40,10 @@ namespace
     // Per instance data
     //
     constexpr AttributeDescriptionList gInstanceDescription{
-        { 1,                                        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mPosition),  MappedGL<GLfloat>::enumerator}},
-        { 2,                                        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mDimension), MappedGL<GLfloat>::enumerator}},
-        { 3,                                        {{3, 3}, offsetof(TrivialShaping::Rectangle, mMatrixTransform),     MappedGL<GLfloat>::enumerator}},
-        {{6, ShaderParameter::Access::Float, true}, {4,      offsetof(TrivialShaping::Rectangle, mColor),               MappedGL<GLubyte>::enumerator}},
+        { 1,        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mPosition),  MappedGL<GLfloat>::enumerator}},
+        { 2,        {2,      offsetof(TrivialShaping::Rectangle, mGeometry.mDimension), MappedGL<GLfloat>::enumerator}},
+        { 3,        {{3, 3}, offsetof(TrivialShaping::Rectangle, mMatrixTransform),     MappedGL<GLfloat>::enumerator}},
+        {{6, true}, {4,      offsetof(TrivialShaping::Rectangle, mColor),               MappedGL<GLubyte>::enumerator}},
     };
 
     VertexSpecification make_VertexSpecification()

--- a/src/libs/graphics/graphics/detail/Logging.h
+++ b/src/libs/graphics/graphics/detail/Logging.h
@@ -10,8 +10,8 @@ namespace ad {
 namespace graphics {
 
 
-constexpr const char * gMainLogger = "logging";
-constexpr const char * gOpenglLogger = "opengl";
+constexpr const char * gMainLogger = "graphics";
+constexpr const char * gOpenglLogger = "graphics::opengl";
 
 
 namespace detail {

--- a/src/libs/graphics/graphics/detail/UnitQuad.cpp
+++ b/src/libs/graphics/graphics/detail/UnitQuad.cpp
@@ -52,7 +52,7 @@ Program make_PassthroughProgram(GLint aTextureUnit)
         {GL_FRAGMENT_SHADER, gTexturingFragmentShader}
     });
 
-    setUniformInt(passthrough, "inputTexture", aTextureUnit);
+    setUniform(passthrough, "inputTexture", aTextureUnit);
 
     return passthrough;
 }

--- a/src/libs/graphics/graphics/effects/Fade.cpp
+++ b/src/libs/graphics/graphics/effects/Fade.cpp
@@ -24,7 +24,7 @@ Fade::Fade() :
             {GL_FRAGMENT_SHADER, fade::gFragmentShader}
     })}
 {
-    setUniformInt(mProgram, "image", gTextureUnit); 
+    setUniform(mProgram, "image", gTextureUnit); 
 }
 
 

--- a/src/libs/graphics/graphics/effects/GaussianBlur.cpp
+++ b/src/libs/graphics/graphics/effects/GaussianBlur.cpp
@@ -168,9 +168,9 @@ GaussianBlur::GaussianBlur()
     LinearFilteredKernel<3> linear = computeLinearFilteredWeights(discreteWeights);
     for (auto & program : mProgramSequence)
     {
-        setUniformInt(program, "image", gTextureUnit); 
-        setUniformFloatArray(program, "offsets", linear.offsets);
-        setUniformFloatArray(program, "weights", linear.weights);
+        setUniform(program, "image", gTextureUnit); 
+        setUniformArray(program, "offsets", linear.offsets);
+        setUniformArray(program, "weights", linear.weights);
     }
 
     // Setup the filter directions.

--- a/src/libs/renderer/renderer/AttributeDimension.cpp
+++ b/src/libs/renderer/renderer/AttributeDimension.cpp
@@ -1,0 +1,25 @@
+#include "AttributeDimension.h"
+
+
+#include <ostream>
+
+
+namespace ad {
+namespace graphics {
+
+
+std::ostream & operator<<(std::ostream & aOut, const AttributeDimension & aAttributeDimension)
+{
+    if (aAttributeDimension.mSecondDimension == 1)
+    {
+        return aOut << aAttributeDimension.mFirstDimension;
+    }
+    else
+    {
+        return aOut << "(" << aAttributeDimension[0] << ", " << aAttributeDimension[1] << ")";
+    }
+}
+
+
+} // namespace graphics
+} // namespace ad

--- a/src/libs/renderer/renderer/AttributeDimension.h
+++ b/src/libs/renderer/renderer/AttributeDimension.h
@@ -1,0 +1,64 @@
+#pragma once
+
+
+#include "GL_Loader.h"
+
+#include <iosfwd>
+
+#include <cassert>
+
+
+namespace ad {
+namespace graphics {
+
+
+struct AttributeDimension
+{
+    /*implicit*/ constexpr AttributeDimension(GLuint aFirst, GLuint aSecond = 1) noexcept :
+        mFirstDimension{aFirst},
+        mSecondDimension{aSecond}
+    {
+        assert (mFirstDimension  <= 4);
+        assert (mSecondDimension <= 4);
+    }
+
+    constexpr GLuint & operator[](std::size_t aIndex)
+    { 
+        assert(aIndex < 2);
+        return (aIndex == 0 ? mFirstDimension : mSecondDimension);
+    }
+
+    constexpr GLuint operator[](std::size_t aIndex) const
+    { 
+        assert(aIndex < 2);
+        return (aIndex == 0 ? mFirstDimension : mSecondDimension);
+    }
+
+    constexpr GLuint countComponents() const noexcept
+    {
+        return mFirstDimension * mSecondDimension;
+    }
+
+    bool operator==(AttributeDimension aRhs)
+    {
+        return mFirstDimension == aRhs.mFirstDimension 
+            && mSecondDimension == aRhs.mSecondDimension;
+    }
+
+    bool operator!=(AttributeDimension aRhs)
+    {
+        return !(*this == aRhs);
+    }
+
+    GLuint mFirstDimension;
+    GLuint mSecondDimension;
+
+    //static constexpr AttributeDimension gScalar{1};
+};
+
+
+std::ostream & operator<<(std::ostream & aOut, const AttributeDimension & aAttributeDimension);
+
+
+} // namespace graphics
+} // namespace ad

--- a/src/libs/renderer/renderer/BufferUtilities.h
+++ b/src/libs/renderer/renderer/BufferUtilities.h
@@ -2,6 +2,7 @@
 
 
 #include "MappedGL.h"
+#include "UniformBuffer.h" // TODO remove when generalized
 
 #include <span>
 

--- a/src/libs/renderer/renderer/CMakeLists.txt
+++ b/src/libs/renderer/renderer/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TARGET_NAME renderer)
 
 set(${TARGET_NAME}_HEADERS
+    AttributeDimension.h
     BufferUtilities.h
     commons.h
     Drawing.h
@@ -20,6 +21,7 @@ set(${TARGET_NAME}_HEADERS
 )
 
 set(${TARGET_NAME}_SOURCES
+    AttributeDimension.cpp
     ShaderSource.cpp
     Shading.cpp
     VertexSpecification.cpp

--- a/src/libs/renderer/renderer/MappedGL.h
+++ b/src/libs/renderer/renderer/MappedGL.h
@@ -79,7 +79,7 @@ constexpr GLenum getByteSize(GLenum aTypeEnum)
         return #enumval;
 
 
-constexpr std::string to_string(GLenum aTypeEnum) 
+inline std::string to_string(GLenum aTypeEnum) 
 {
     switch(aTypeEnum)
     {

--- a/src/libs/renderer/renderer/MappedGL.h
+++ b/src/libs/renderer/renderer/MappedGL.h
@@ -11,12 +11,15 @@ namespace graphics {
 
 #define MAP(trait, gltype, enumval)                     \
     template <> struct trait<gltype>                    \
-    { static constexpr GLenum enumerator = enumval; };  \
+    { static constexpr GLenum enumerator = enumval; };  
+
+#define REVERSE_MAP(trait, gltype, enumval)             \
+    template <> struct trait##_r<enumval>               \
+    { using type = gltype; };
 
 #define MAP_AND_REVERSE(trait, gltype, enumval)         \
     MAP(trait, gltype, enumval)                         \
-    template <> struct trait##_r<enumval>               \
-    { using type = gltype; };
+    REVERSE_MAP(trait, gltype, enumval)
 
 //
 // Built-in types
@@ -41,6 +44,8 @@ MAP_AND_REVERSE(MappedGL, GLshort, GL_SHORT);
 MAP_AND_REVERSE(MappedGL, GLushort, GL_UNSIGNED_SHORT);
 MAP_AND_REVERSE(MappedGL, GLint, GL_INT);
 MAP_AND_REVERSE(MappedGL, GLuint, GL_UNSIGNED_INT);
+// Only reverse is possible, because GLboolean is the same type as GLubyte
+REVERSE_MAP(MappedGL, GLboolean, GL_BOOL);
 
 
 #define TYPEENUMCASE(enumval)           \
@@ -60,6 +65,7 @@ constexpr GLenum getByteSize(GLenum aTypeEnum)
         TYPEENUMCASE(GL_UNSIGNED_SHORT);
         TYPEENUMCASE(GL_INT);
         TYPEENUMCASE(GL_UNSIGNED_INT);
+        TYPEENUMCASE(GL_BOOL);
     default:
         throw std::domain_error{"Invalid type enumerator."};
     }
@@ -67,6 +73,31 @@ constexpr GLenum getByteSize(GLenum aTypeEnum)
 
 #undef TYPEENUMCASE
 
+
+#define TYPEENUMCASE(enumval)           \
+    case enumval:                       \
+        return #enumval;
+
+
+constexpr std::string to_string(GLenum aTypeEnum) 
+{
+    switch(aTypeEnum)
+    {
+        TYPEENUMCASE(GL_FLOAT);
+        TYPEENUMCASE(GL_DOUBLE);
+        TYPEENUMCASE(GL_BYTE);
+        TYPEENUMCASE(GL_UNSIGNED_BYTE);
+        TYPEENUMCASE(GL_SHORT);
+        TYPEENUMCASE(GL_UNSIGNED_SHORT);
+        TYPEENUMCASE(GL_INT);
+        TYPEENUMCASE(GL_UNSIGNED_INT);
+        TYPEENUMCASE(GL_BOOL);
+    default:
+        throw std::domain_error{"Invalid type enumerator."};
+    }
+}
+
+#undef TYPEENUMCASE
 
 //
 // Pixel formats

--- a/src/libs/renderer/renderer/Uniforms.h
+++ b/src/libs/renderer/renderer/Uniforms.h
@@ -16,108 +16,119 @@ namespace graphics {
     // Note: It is not obvious whether a const program should allow to change its parameters.
     // Yet, designing the API this way allow to make most render() member method constant.
 
+    // Note: not taking a string_view, as we need a null-terminated c string from the name.
+    /// \brief Overload taking the uniform name instead of its location.
+    template <class T_value>
     inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+                           const T_value & aValue)
+    {
+        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
+        setUniform(aProgram, location, aValue);
+    }
+    
+
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Matrix<3, 3, GLfloat> & aMatrix)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniformMatrix3fv(aProgram, location, 1, false, aMatrix.data());
+        glProgramUniformMatrix3fv(aProgram, aLocation, 1, false, aMatrix.data());
     }
 
 
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Matrix<4, 4, GLfloat> & aMatrix)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniformMatrix4fv(aProgram, location, 1, false, aMatrix.data());
+        glProgramUniformMatrix4fv(aProgram, aLocation, 1, false, aMatrix.data());
     }
 
     template <class T_derived>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Vector<T_derived, 2, GLint> & aVector)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform2i(aProgram, location, aVector[0], aVector[1]);
+        glProgramUniform2i(aProgram, aLocation, aVector[0], aVector[1]);
     }
 
 
     template <class T_derived>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Vector<T_derived, 3, GLint> & aVector)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform3i(aProgram, location, aVector[0], aVector[1], aVector[2]);
+        glProgramUniform3i(aProgram, aLocation, aVector[0], aVector[1], aVector[2]);
     }
 
+
     template <class T_derived>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Vector<T_derived, 2, GLfloat> & aVector)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform2f(aProgram, location, aVector[0], aVector[1]);
+        glProgramUniform2f(aProgram, aLocation, aVector[0], aVector[1]);
     }
 
 
     template <class T_derived>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Vector<T_derived, 3, GLfloat> & aVector)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform3f(aProgram, location, aVector[0], aVector[1], aVector[2]);
+        glProgramUniform3f(aProgram, aLocation, aVector[0], aVector[1], aVector[2]);
     }
 
 
     template <class T_hdrNumber>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::hdr::Rgb<T_hdrNumber> & aColor)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform3f(aProgram, location, (GLfloat)aColor[0], (GLfloat)aColor[1], (GLfloat)aColor[2]);
+        glProgramUniform3f(aProgram, aLocation, (GLfloat)aColor[0], (GLfloat)aColor[1], (GLfloat)aColor[2]);
     }
 
 
     template <class T_derived>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::Vector<T_derived, 4, GLfloat> & aVector)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform4f(aProgram, location, aVector[0], aVector[1], aVector[2], aVector[3]);
+        glProgramUniform4f(aProgram, aLocation, aVector[0], aVector[1], aVector[2], aVector[3]);
     }
 
 
     template <class T_hdrNumber>
-    inline void setUniform(const Program & aProgram, const std::string & aNameInShader,
+    inline void setUniform(const Program & aProgram, GLint aLocation,
                            const math::hdr::Rgba<T_hdrNumber> & aColor)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform4f(aProgram, location, (GLfloat)aColor[0], (GLfloat)aColor[1], (GLfloat)aColor[2], (GLfloat)aColor[3]);
+        glProgramUniform4f(aProgram, aLocation, (GLfloat)aColor[0], (GLfloat)aColor[1], (GLfloat)aColor[2], (GLfloat)aColor[3]);
     }
 
-    inline void setUniformFloat(const Program & aProgram, const std::string & aNameInShader,
-                                GLfloat aFloat)
+
+    inline void setUniform(const Program & aProgram, GLint aLocation,
+                           GLfloat aFloat)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform1f(aProgram, location, aFloat);
+        glProgramUniform1f(aProgram, aLocation, aFloat);
     }
 
 
-    inline void setUniformInt(const Program & aProgram, const std::string & aNameInShader,
-                              GLint aInteger)
+    inline void setUniform(const Program & aProgram, GLint aLocation,
+                           GLint aInteger)
     {
-        GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
-        glProgramUniform1i(aProgram, location, aInteger);
+        glProgramUniform1i(aProgram, aLocation, aInteger);
     }
 
 
-    inline void setUniformFloatArray(const Program & aProgram, const std::string & aNameInShader,
-                                     std::span<const GLfloat> aFloats)
+    inline void setUniform(const Program & aProgram, GLint aLocation,
+                           GLuint aUnsignedInteger)
+    {
+        glProgramUniform1ui(aProgram, aLocation, aUnsignedInteger);
+    }
+
+
+    /// \brief  Set an array of scalar uniforms (i.e. each uniform in the array has dimension 1).
+    inline void setUniformArray(const Program & aProgram, const std::string & aNameInShader,
+                                std::span<const GLfloat> aFloats)
     {
         GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
         glProgramUniform1fv(aProgram, location, (GLsizei)aFloats.size(), aFloats.data());
     }
 
 
-    inline void setUniformIntArray(const Program & aProgram, const std::string & aNameInShader,
-                                   std::span<const GLint> aIntegers)
+    /// \brief  Set an array of scalar uniforms (i.e. each uniform in the array has dimension 1).
+    inline void setUniformArray(const Program & aProgram, const std::string & aNameInShader,
+                                std::span<const GLint> aIntegers)
     {
         GLint location = glGetUniformLocation(aProgram, aNameInShader.c_str());
         glProgramUniform1iv(aProgram, location, (GLsizei)aIntegers.size(), aIntegers.data());

--- a/src/libs/renderer/renderer/VertexSpecification.cpp
+++ b/src/libs/renderer/renderer/VertexSpecification.cpp
@@ -23,7 +23,7 @@ std::ostream & operator<<(std::ostream &aOut, const AttributeDescription & aDesc
     return aOut << "Index " << aDescription.mIndex << " | "
                 << "Dimension " << aDescription.mDimension << " | "
                 << "Offset " << aDescription.mOffset << " | "
-                << "Data " << aDescription.mDataType
+                << "Data " << aDescription.mComponentType
                 ;
 }
 
@@ -40,7 +40,7 @@ void attachBoundVertexBuffer(AttributeDescription aAttribute,
             {
                 glVertexAttribPointer(aAttribute.mIndex + second,
                                       aAttribute.mDimension[0],
-                                      aAttribute.mDataType,
+                                      aAttribute.mComponentType,
                                       aAttribute.mNormalize,
                                       aStride,
                                       reinterpret_cast<const void*>(aAttribute.mOffset 
@@ -55,7 +55,7 @@ void attachBoundVertexBuffer(AttributeDescription aAttribute,
             {
                 glVertexAttribIPointer(aAttribute.mIndex + second,
                                        aAttribute.mDimension[0],
-                                       aAttribute.mDataType,
+                                       aAttribute.mComponentType,
                                        aStride,
                                        reinterpret_cast<const void*>(aAttribute.mOffset
                                        + second * aAttribute.sizeBytesFirstDimension()));

--- a/src/libs/renderer/renderer/VertexSpecification.cpp
+++ b/src/libs/renderer/renderer/VertexSpecification.cpp
@@ -17,17 +17,6 @@ namespace {
 
 } // anonymous
 
-std::ostream & operator<<(std::ostream & aOut, const AttributeDimension & aAttributeDimension)
-{
-    if (aAttributeDimension.mSecondDimension == 1)
-    {
-        return aOut << aAttributeDimension.mFirstDimension;
-    }
-    else
-    {
-        return aOut << "[" << aAttributeDimension[0] << ", " << aAttributeDimension[1] << "]";
-    }
-}
 
 std::ostream & operator<<(std::ostream &aOut, const AttributeDescription & aDescription)
 {

--- a/src/libs/renderer/renderer/VertexSpecification.h
+++ b/src/libs/renderer/renderer/VertexSpecification.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AttributeDimension.h"
 #include "gl_helpers.h"
 #include "GL_Loader.h"
 #include "MappedGL.h"
@@ -9,8 +10,6 @@
 #include <span>
 #include <type_traits>
 #include <vector>
-
-#include <cassert>
 
 
 namespace ad {
@@ -112,7 +111,10 @@ inline void unbind(const VertexSpecification & aVertexSpecification)
 
 
 
-/// \brief Describes the shader parameter aspect of the attribute (layout id, value type, normalization)
+/// \brief Describes the shader parameter aspect of the attribute (location index, value type, normalization)
+///
+/// This is a description from the Cpp program point of view, more than a shader program introspection.
+/// In the sense that is is not concerned with the exact attribute type in the shader, but knows if the data should be normalized.
 struct ShaderParameter
 {
     enum class Access
@@ -136,43 +138,6 @@ struct ShaderParameter
     Access mTypeInShader{Access::Float}; // destination data type
     bool mNormalize{false}; // if destination is float and source is integral, should it be normalized (value/type_max_value)
 };
-
-
-struct AttributeDimension
-{
-    /*implicit*/ constexpr AttributeDimension(GLuint aFirst, GLuint aSecond = 1) noexcept :
-        mFirstDimension{aFirst},
-        mSecondDimension{aSecond}
-    {
-        assert (mFirstDimension  <= 4);
-        assert (mSecondDimension <= 4);
-    }
-
-    constexpr GLuint & operator[](std::size_t aIndex)
-    { 
-        assert(aIndex < 2);
-        return (aIndex == 0 ? mFirstDimension : mSecondDimension);
-    }
-
-    constexpr GLuint operator[](std::size_t aIndex) const
-    { 
-        assert(aIndex < 2);
-        return (aIndex == 0 ? mFirstDimension : mSecondDimension);
-    }
-
-    constexpr GLuint countComponents() const noexcept
-    {
-        return mFirstDimension * mSecondDimension;
-    }
-
-    GLuint mFirstDimension;
-    GLuint mSecondDimension;
-
-    //static constexpr AttributeDimension gScalar{1};
-};
-
-
-std::ostream & operator<<(std::ostream & aOut, const AttributeDimension & aAttributeDimension);
 
 
 /// \brief Describes client perspective of the attribute, i.e. as an argument provided by the client.

--- a/src/libs/renderer/renderer/VertexSpecification.h
+++ b/src/libs/renderer/renderer/VertexSpecification.h
@@ -200,6 +200,13 @@ std::ostream & operator<<(std::ostream &aOut, const AttributeDescription & aDesc
 typedef std::initializer_list<AttributeDescription> AttributeDescriptionList;
 
 
+/// \brief Attach currently bound vertex buffer object to currently bound vertex array objet.
+/// \param aAttribute Describe the format of the buffer data and the associated parameter in shader program.
+void attachBoundVertexBuffer(AttributeDescription aAttribute,
+                             GLsizei aStride,
+                             GLuint aAttributeDivisor = 0);
+
+
 /***
  *
  * Vertex Buffer

--- a/src/libs/renderer/renderer/VertexSpecification.h
+++ b/src/libs/renderer/renderer/VertexSpecification.h
@@ -143,13 +143,12 @@ struct ShaderParameter
 /// \brief Describes client perspective of the attribute, i.e. as an argument provided by the client.
 struct ClientAttribute
 {
-    // TODO extend to multiple dimensions for "multi-attributes" entries, such as matrices
     AttributeDimension mDimension;
     size_t mOffset;     // offset for the attribute within the vertex data structure (interleaved)
-    GLenum mDataType;   // attribute source data type
+    GLenum mComponentType;   // data individual components' type.
 
     constexpr GLsizei sizeBytesFirstDimension() const
-    { return mDimension[0] * getByteSize(mDataType); }
+    { return mDimension[0] * getByteSize(mComponentType); }
 
     constexpr GLsizei sizeBytes() const
     { return mDimension[1] * sizeBytesFirstDimension(); }

--- a/src/libs/renderer/renderer/VertexSpecification.h
+++ b/src/libs/renderer/renderer/VertexSpecification.h
@@ -121,14 +121,15 @@ struct ShaderParameter
         Integer,
     };
 
-    constexpr ShaderParameter(GLuint aAttributeIndex) :
-        mIndex(aAttributeIndex)
+    // Note: can only normalize for float shader parameters, no need to take the access parameter here.
+    /*implicit*/ constexpr ShaderParameter(GLuint aAttributeIndex, bool aNormalize=false) :
+        mIndex(aAttributeIndex),
+        mNormalize(aNormalize)
     {}
 
-    constexpr ShaderParameter(GLuint aAttributeIndex, Access aAccess, bool aNormalize=false) :
+    constexpr ShaderParameter(GLuint aAttributeIndex, Access aAccess) :
         mIndex(aAttributeIndex),
-        mTypeInShader(aAccess),
-        mNormalize(aNormalize)
+        mTypeInShader(aAccess)
     {}
 
     GLuint mIndex; // index to match in vertex shader.


### PR DESCRIPTION
closes #69
- Implement a shader-program introspection prototype.
- Minor: refine logging level of GL notifications and logger names.
- Handle bidimensionnal shader attributes via a Dimension struct.
- Prevent construction of ShaderParameter with normalize and int access.
- Take-out attaching a single attribute in a separate function.
- Move AttributeDimension to its own pair of files.
- Rename ClientAttribute::mDataType to mComponentType.
- Extend gl map with GL_BOOLEAN, add to_string(GLenum aType).
- Fix clang compilation (remove constexpr on std::string return type).
- [shader_introspection] Display block ID.
- Upgrade to spdlog 1.11.0.
- Add overloads taking the location to Uniforms, remove type suffix.
- Include missing header.
