### PR TITLE
topic/snacman#74 text rendering

### DIFF
--- a/src/libs/arte/arte/Freetype.h
+++ b/src/libs/arte/arte/Freetype.h
@@ -143,7 +143,7 @@ private:
 // the instance becoming independant of the FontFace and its currently active glyph.
 // Yet, we keep it minimal (and optimal) as the current use case can live with the limitations.
 /// \brief Wrap the glyph slot currently active in a FontFace.
-/// \warning The FontFace instance must outlive the GlyphBitmap.
+/// \warning The FontFace instance must outlive the GlyphBitmap. // TODO 
 class GlyphSlot
 {
     friend class FontFace;

--- a/src/libs/arte/arte/Freetype.h
+++ b/src/libs/arte/arte/Freetype.h
@@ -226,6 +226,13 @@ public:
         return setPixelSize({0, aHeight});
     }
 
+    math::Size<2, int> getPixelSize() const
+    {
+        // Note: this is likely not the real pixel size, but will be revisited if the need arises.
+        // It returns the "Pixels per EM", which seems to be set by setPixelSize() .
+        return {get()->size->metrics.x_ppem, get()->size->metrics.y_ppem};
+    }
+
     bool hasGlyph(CharCode aCharcode) const
     {
         // Explicit conversion to check it cannot lose precision.
@@ -248,7 +255,7 @@ public:
         return GlyphSlot{get()->glyph, glyphIndex};
     }
 
-    math::Vec<2, float> kern(FT_UInt aLeftGlyphIndex, FT_UInt aRightGlyphIndex)
+    math::Vec<2, float> kern(FT_UInt aLeftGlyphIndex, FT_UInt aRightGlyphIndex) const
     {
         FT_Vector kerning;
         FT_Get_Kerning(*this, aLeftGlyphIndex, aRightGlyphIndex, FT_KERNING_DEFAULT, &kerning);

--- a/src/libs/graphics/graphics/ApplicationGlfw.h
+++ b/src/libs/graphics/graphics/ApplicationGlfw.h
@@ -155,6 +155,7 @@ public:
         return handleEvents();
     }
 
+    // TODO should return a plain reference, the app interface will not be valide anyway if this is destroyed.
     std::shared_ptr<AppInterface> getAppInterface()
     {
         return mAppInterface;

--- a/src/libs/graphics/graphics/Texting.cpp
+++ b/src/libs/graphics/graphics/Texting.cpp
@@ -75,12 +75,6 @@ Texting::Texting(const filesystem::path & aFontPath,
         (aTextureFiltering == Filtering::Linear) ? (GLenum)GL_LINEAR : GL_NEAREST
     };
 
-    // TODO I don't like this coupling to GlyphUtilities.cpp, DynamicGlyphCache::at()
-    // where we have to provide the same offset to the shader.
-    setUniform(mGpuProgram, "u_BoundingOffsets_pixel", math::Vec<2, GLfloat>{
-        (GLfloat)ribonMargins.x() / 2.f, // division by 2 matches RenderedGlyph data 
-        (GLfloat)ribonMargins.y()});
-
     // Font setup
     mFontFace.inverseYAxis(true);
     mFontFace.setPixelHeight(static_cast<int>(glyphPixelHeight));

--- a/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
+++ b/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
@@ -97,7 +97,7 @@ RenderedGlyph DynamicGlyphCache::at(arte::CharCode aCharCode, const arte::FontFa
                 // Adding margin on each dimension allows to make sure the top and right border pixels are not discarded, when rendering at matching resolution.
                 // Important: add half horizontal margin on each side to avoid bleeding, and whole vertical margin on top and bottom (no vertical bleeding in a ribbon).
                 {fixedToFloat(slot.metric().width) + margins.x(), fixedToFloat(slot.metric().height) + 2 * margins.y()}, 
-                {fixedToFloat(slot.metric().horiBearingX), fixedToFloat(slot.metric().horiBearingY)},
+                {fixedToFloat(slot.metric().horiBearingX) - margins.x() / 2.f, fixedToFloat(slot.metric().horiBearingY) + margins.y()},
                 {fixedToFloat(slot.metric().horiAdvance), 0.f /* hardcoded horizontal layout */},
                 slot.index()
             };
@@ -170,7 +170,7 @@ Texture makeTightGlyphAtlas(const arte::FontFace & aFontFace,
                     0,
                     // See DynamicGlyphCache::at() for the ratrionale behind the addition
                     {fixedToFloat(slot.metric().width) + aMargins.x(), fixedToFloat(slot.metric().height) + 2 * aMargins.y()}, 
-                    {fixedToFloat(slot.metric().horiBearingX), fixedToFloat(slot.metric().horiBearingY)},
+                    {fixedToFloat(slot.metric().horiBearingX) - aMargins.x() / 2.f, fixedToFloat(slot.metric().horiBearingY) + aMargins.y()},
                     {fixedToFloat(slot.metric().horiAdvance), 0.f /* hardcoded horizontal layout */},
                     slot.index()
                 }
@@ -201,7 +201,7 @@ Texture makeTightGlyphAtlas(const arte::FontFace & aFontFace,
             GL_UNSIGNED_BYTE,
             1
         };
-        rendered.texture = &ribon.texture;
+        rendered.texture = &ribon.texture; // Replace the nullptr with the actual the ribon texture.
         rendered.offsetInTexture = ribon.write(bitmap.data(), inputParams) - (aMargins.x() / 2);
         aGlyphMap.insert({charcode, rendered});
     }

--- a/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
+++ b/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
@@ -245,7 +245,7 @@ math::Size<2, GLfloat> getStringDimension(const std::string & aString,
     math::Size<2, GLfloat> result{static_cast<math::Size<2, GLfloat>>(aFontFace.getPixelSize())};
     forEachGlyph(aString, math::Position<2, GLfloat>{0.f, 0.f}, aGlyphCache, aFontFace, [&result](const auto & rendered, auto position)
     {
-        result = result, (position + rendered.penAdvance).as<math::Size>();
+        result = (position + rendered.penAdvance).as<math::Size>();
     });
     return result;
 }

--- a/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
+++ b/src/libs/graphics/graphics/detail/GlyphUtilities.cpp
@@ -241,7 +241,7 @@ math::Size<2, GLfloat> getStringDimension(const std::string & aString,
     math::Size<2, GLfloat> result{static_cast<math::Size<2, GLfloat>>(aFontFace.getPixelSize())};
     forEachGlyph(aString, math::Position<2, GLfloat>{0.f, 0.f}, aGlyphCache, aFontFace, [&result](const auto & rendered, auto position)
     {
-        result = (position + rendered.penAdvance).as<math::Size>();
+        result = (position + rendered.penAdvance).template as<math::Size>();
     });
     return result;
 }

--- a/src/libs/graphics/graphics/detail/GlyphUtilities.h
+++ b/src/libs/graphics/graphics/detail/GlyphUtilities.h
@@ -110,13 +110,13 @@ struct StaticGlyphCache
 
     StaticGlyphCache(const arte::FontFace & aFontFace,
                      arte::CharCode aFirst, arte::CharCode aLast,
-                     math::Vec<2, GLint> aDimensionExtension = {1, 0});
+                     math::Vec<2, GLint> aDimensionExtension = TextureRibon::gRecommendedMargins);
 
     RenderedGlyph at(arte::CharCode aCharCode) const;
 
     Texture atlas{0};
     GlyphMap glyphMap;
-    arte::CharCode placeholder = 0x3F; // '?'
+    static const arte::CharCode placeholder = 0x3F; // '?'
 };
 
 
@@ -153,12 +153,28 @@ struct DynamicGlyphCache
 
 
 // TODO aPixelToLocal should be removed, when the Texting rendering does all "local layout" in pixel coordinates
+/// \deprecated
 void forEachGlyph(const std::string & aString,
                   math::Position<2, GLfloat> aPenOrigin_w,
                   DynamicGlyphCache & aGlyphCache,
                   arte::FontFace & aFontFace,
                   math::Size<2, GLfloat> aPixelToLocal,
                   std::function<void(RenderedGlyph, math::Position<2, GLfloat>)> aGlyphCallback);
+
+
+/// @brief Prepare a string for rendering by invoking `aGlyphCallback` for each glyph in `aString`.
+/// @param aPenOrigin_u Pen origin when starting to write the string, expressed in pixels of the render target.
+void forEachGlyph(const std::string & aString,
+                  math::Position<2, GLfloat> aPenOrigin_p,
+                  const StaticGlyphCache & aGlyphCache,
+                  const arte::FontFace & aFontFace,
+                  std::function<void(const RenderedGlyph &, math::Position<2, GLfloat>)> aGlyphCallback);
+
+
+// TODO only provide the dimension in the direction of writing at the moment (the other will be zero).
+math::Size<2, GLfloat> getStringDimension(const std::string & aString,
+                                          const StaticGlyphCache & aGlyphCache,
+                                          const arte::FontFace & aFontFace);
 
 
 } // namespace detail

--- a/src/libs/graphics/graphics/detail/GlyphUtilities.h
+++ b/src/libs/graphics/graphics/detail/GlyphUtilities.h
@@ -77,10 +77,12 @@ inline GLint TextureRibon::write(const std::byte * aData, InputImageParameters a
 struct RenderedGlyph
 {
     // TODO Storing a naked texture pointer is not ideal
+    // Note: the texture is stored here for the cases where several textures are used for a single logical font atlas (dynamic)
+    // Ideally, this association should be handled by the client, but it would mean 1 GlyphMap / texture (complicating lookups).
     Texture * texture;
     GLint offsetInTexture; // The texture is a "1D" strip, only horizontal position.
-    math::Size<2, GLfloat> controlBoxSize;
-    math::Vec<2, GLfloat> bearing;
+    math::Size<2, GLfloat> controlBoxSize; // Including added margin if any
+    math::Vec<2, GLfloat> bearing; // Including the added margin if any
     math::Vec<2, GLfloat> penAdvance;
     unsigned int freetypeIndex; // Notably usefull for kerning queries.
 };
@@ -103,10 +105,6 @@ Texture makeTightGlyphAtlas(const arte::FontFace & aFontFace,
 
 struct StaticGlyphCache
 {
-    Texture atlas{0};
-    GlyphMap glyphMap;
-    arte::CharCode placeholder = 0x3F; // '?'
-
     // The empty cache
     StaticGlyphCache() = default;
 
@@ -115,6 +113,10 @@ struct StaticGlyphCache
                      math::Vec<2, GLint> aDimensionExtension = {1, 0});
 
     RenderedGlyph at(arte::CharCode aCharCode) const;
+
+    Texture atlas{0};
+    GlyphMap glyphMap;
+    arte::CharCode placeholder = 0x3F; // '?'
 };
 
 

--- a/src/libs/graphics/graphics/shaders.h
+++ b/src/libs/graphics/graphics/shaders.h
@@ -241,7 +241,6 @@ namespace texting
         layout(location=5) in vec2  in_Bearing;
         layout(location=6) in vec4  in_Color;
         
-        uniform vec2 u_BoundingOffsets_pixel;
         uniform vec2 u_PixelToWorld;
         uniform mat3 u_WorldToCamera;
         uniform mat3 u_Projection;
@@ -252,7 +251,7 @@ namespace texting
         void main(void)
         {
             // Go back (left) by horizontal offset, but advance (up) by vertical offset.
-            vec2 worldBearing     = vec2(in_Bearing.x - u_BoundingOffsets_pixel.x, in_Bearing.y + u_BoundingOffsets_pixel.y) * u_PixelToWorld;
+            vec2 worldBearing     = in_Bearing * u_PixelToWorld;
             vec2 worldBoundingBox = in_BoundingBox * u_PixelToWorld;
             vec2 worldPosition    = in_Position_w + worldBearing + (ve_Position_u * worldBoundingBox);
 


### PR DESCRIPTION
- Embed the margins directly into RenderederGlyph bearing.
- Enrich GlyphUtilities, overload forEachGlyph add getStringDimension.
- Fix typo in getStringDimension().
- Rework glyph margins (the margin is added on each side).
