### PR TITLE
topic/snacman#136 secondary window

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -45,7 +45,7 @@ class GraphicsConan(ConanFile):
         ("imgui/1.89.8"),
 
         ("handy/15a1bb8eaa@adnn/develop"),
-        ("math/4173650c1e@adnn/develop"),
+        ("math/93cb736b19@adnn/develop"),
     )
 
     build_policy = "missing"

--- a/src/apps/prototypes/tiler/main.cpp
+++ b/src/apps/prototypes/tiler/main.cpp
@@ -72,7 +72,7 @@ int main(void)
     glfwMakeContextCurrent(window);
     gladLoadGL();
 
-    ad::graphics::AppInterface appInterface{ [&window](){glfwSetWindowShouldClose(window, GLFW_TRUE);} };
+    ad::graphics::AppInterface appInterface{ {.mClose = [&window](){glfwSetWindowShouldClose(window, GLFW_TRUE);}} };
     glfwSetWindowUserPointer(window, &appInterface);
     // Explicitly call it, because it is used to complete the appInterface setup
     {

--- a/src/libs/graphics/graphics/AppInterface.cpp
+++ b/src/libs/graphics/graphics/AppInterface.cpp
@@ -9,10 +9,10 @@ namespace ad {
 namespace graphics {
 
 
-AppInterface::AppInterface(std::function<void()> aCloseAppCallback) :
+AppInterface::AppInterface(WindowCallbacks aWindowCallbacks) :
     mWindowSize{0, 0},
     mFramebufferSize{0, 0},
-    mCloseAppCallback{std::move(aCloseAppCallback)}
+    mWindowCallbacks{std::move(aWindowCallbacks)}
 {
     //
     // General OpenGL setups
@@ -33,9 +33,35 @@ AppInterface::AppInterface(std::function<void()> aCloseAppCallback) :
 }
 
 
-void AppInterface::requestCloseApplication()
+void AppInterface::requestCloseWindow()
 {
-    mCloseAppCallback();
+    mWindowCallbacks.mClose();
+}
+
+
+void AppInterface::showWindow()
+{
+    mWindowCallbacks.mShow();
+}
+
+
+void AppInterface::hideWindow()
+{
+    mWindowCallbacks.mHide();
+}
+
+
+void AppInterface::callbackWindowVisibility(bool aShown)
+{
+    if (aShown)
+    {
+        ADLOG(gMainLogger, info)("The window is shown.");
+    }
+    else
+    {
+        ADLOG(gMainLogger, info)("The window is hidden.");
+    }
+    mWindowIsHidden = !aShown; 
 }
 
 
@@ -43,11 +69,11 @@ void AppInterface::callbackWindowMinimize(bool aMinimized)
 {
     if (aMinimized)
     {
-        ADLOG(gMainLogger, info)("The window has be minimized.");
+        ADLOG(gMainLogger, info)("The window has been minimized.");
     }
     else
     {
-        ADLOG(gMainLogger, info)("The window has be restored.");
+        ADLOG(gMainLogger, info)("The window has been restored.");
     }
     mWindowIsMinimized = aMinimized;
 }

--- a/src/libs/graphics/graphics/ApplicationGlfw.h
+++ b/src/libs/graphics/graphics/ApplicationGlfw.h
@@ -445,7 +445,9 @@ struct NullInhibiter
 
 // TODO Ad 2024/05/28:
 // only register the subset actually provided by T_callbackProvider (so it does not need to implement them all)
-/// \brief Register all callbacks at once, that should be available as member functions of `aProvider`.
+/// \brief Register all the callbacks at once. Callbacks have to be available as member functions of `aProvider`.
+/// \param aInhibiter A class that will be given the opportunity to capture input, thus inhibiting the registered provider.
+///  Can be `nullptr`, to disable.
 template <class T_callbackProvider, class T_inhibiter>
 void registerGlfwCallbacks(graphics::AppInterface & aAppInterface,
                            T_callbackProvider & aProvider,
@@ -453,6 +455,11 @@ void registerGlfwCallbacks(graphics::AppInterface & aAppInterface,
                            const T_inhibiter * aInhibiter = &NullInhibiter::gInstance)
 {
     using namespace std::placeholders;
+
+    if(aInhibiter == nullptr)
+    {
+        return registerGlfwCallbacks(aAppInterface, aProvider, aEscBehaviour, &NullInhibiter::gInstance);
+    }
 
     aAppInterface.registerMouseButtonCallback(
         [aInhibiter, &aProvider](int button, int action, int mods, double xpos, double ypos)

--- a/src/libs/graphics/graphics/ApplicationGlfw.h
+++ b/src/libs/graphics/graphics/ApplicationGlfw.h
@@ -171,7 +171,7 @@ private:
                     ApplicationFlag aFlags,
                     int aGLVersionMajor, int aGLVersionMinor,
                     WindowHints aCustomWindowHints) :
-        mGlfwInitialization{initializeGlfw()},
+        mGlfwInitialization{},
         mWindow{initializeWindow(aName, 
                                  aFlags,
                                  aWidth, aHeight, 
@@ -291,7 +291,7 @@ private:
         appInterface->callbackFramebufferSize(width, height);
     }
 
-    Guard initializeGlfw()
+    static Guard InitializeGlfw()
     {
         glfwSetErrorCallback(error_callback);
         if (!glfwInit())
@@ -380,7 +380,16 @@ private:
         }
     }
 
-    Guard mGlfwInitialization;
+    // This structure initializes a static variable while initializing Glfw, and terminate Glfw on variable destruction.
+    // This initialize Glfw only once (not a requirement), and more importantly destruct it only once after main() returns.
+    // At this point no more GLFWwindow should still exist.
+    struct InitGlfw
+    {
+        InitGlfw()
+        { 
+            static Guard mGuardedInit{InitializeGlfw()};
+        }
+    } mGlfwInitialization;
     ResourceGuard<GLFWwindow*> mWindow;
     std::shared_ptr<AppInterface> mAppInterface;
 };

--- a/src/libs/graphics/graphics/CameraUtilities.h
+++ b/src/libs/graphics/graphics/CameraUtilities.h
@@ -75,7 +75,7 @@ void setOrthographicView(T_engine3D & aEngine,
 }
 
 
-/// @brief Get a transformation from parent space to camera space, right-handed.
+/// @brief Get a transformation from parent space to camera space, right-handed. Look-at camera.
 template <class T_number>
 inline constexpr math::AffineMatrix<4, T_number> getCameraTransform(
     math::Position<3, T_number> aCameraPosition,

--- a/src/libs/imguiui/imguiui/ImguiUi.cpp
+++ b/src/libs/imguiui/imguiui/ImguiUi.cpp
@@ -68,7 +68,7 @@ namespace {
     {
         auto userData = retrieveUserData(window);
         // Keeping track of previous context should not be necessary,
-        // but let's be good little soldiers
+        // but let's be good citizens.
         auto previousContext = ImGui::GetCurrentContext();
 
         ImGui::SetCurrentContext(userData->mContext);
@@ -114,7 +114,7 @@ void ImguiUi::registerGlfwCallbacks(const graphics::ApplicationGlfw & aApplicati
     GLFWwindow * window = aApplication.getGlfwWindow();
     graphics::ApplicationGlfw::WindowUserData * previousData =
         static_cast<graphics::ApplicationGlfw::WindowUserData *>(glfwGetWindowUserPointer(window));
-    mUserData = std::make_unique<WindowUserData>(*previousData);
+    mUserData = std::make_unique<WindowUserData>(WindowUserData{*previousData});
     mUserData->mContext = mContext;
     glfwSetWindowUserPointer(window, mUserData.get());
 

--- a/src/libs/imguiui/imguiui/ImguiUi.cpp
+++ b/src/libs/imguiui/imguiui/ImguiUi.cpp
@@ -7,13 +7,26 @@
 #include <imgui_backends/imgui_impl_opengl3.h>
 #include <mutex>
 
+
+namespace ad {
+namespace imguiui {
+
+
 namespace {
 
-    ImGuiIO & initializeImgui(GLFWwindow * aWindow)
+    ImGuiContext * initializeContext()
     {
         // Setup Dear ImGui context
         IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
+        ImGuiContext * context = ImGui::CreateContext();
+        // CreateContext only set the current context to the new one if none were present before
+        // but we need it set for the following setup
+        ImGui::SetCurrentContext(context);
+        return context;
+    }
+
+    ImGuiIO & initializeImgui(GLFWwindow * aWindow)
+    {
         ImGuiIO &io = ImGui::GetIO();
         // Setup Dear ImGui style
         ImGui::StyleColorsDark();
@@ -41,32 +54,97 @@ namespace {
         ImGui::DestroyContext();
     }
 
+
+    ImguiUi::WindowUserData * retrieveUserData(GLFWwindow* window)
+    {
+        return static_cast<ImguiUi::WindowUserData *>(glfwGetWindowUserPointer(window));
+    }
+
+
+    // Restore the ImGuiContext associated to the GLFWWindow,
+    // then forward to the ImGui callback.
+    template <auto F_imguiCallback, typename... VA_args>
+    void implCallback(GLFWwindow* window, VA_args... aArgs)
+    {
+        auto userData = retrieveUserData(window);
+        // Keeping track of previous context should not be necessary,
+        // but let's be good little soldiers
+        auto previousContext = ImGui::GetCurrentContext();
+
+        ImGui::SetCurrentContext(userData->mContext);
+        F_imguiCallback(window, std::forward<VA_args>(aArgs)...);
+        ImGui::SetCurrentContext(previousContext);
+    }
+
 } // anonymous namespace
 
 
-namespace ad {
-namespace imguiui {
-
-
 ImguiUi::ImguiUi(const graphics::ApplicationGlfw & aApplication) :
+    mContext{initializeContext()},
     mIo{initializeImgui(aApplication.getGlfwWindow())}
-{}
+{
+    // #igwp82 Setting the current context to NULL does not work, because
+    // ImGui installs a customm window_procedure on _WIN32: ImGui_ImplGlfw_WndProc()
+    // this procedures retrieve the ImGui context, which would be null at most points...
+    // TODO Ad 2024/08/08: This means that the wrong context is sometimes retrieves when several windows are in flight.
+    // We might handle that by overriding with a custom window_proc and user data.
+    //ImGui::SetCurrentContext(nullptr);
+}
 
 
 ImguiUi::~ImguiUi()
 {
+    ImGui::SetCurrentContext(mContext);
     terminateImgui();
 }
 
+
+void ImguiUi::registerGlfwCallbacks(const graphics::ApplicationGlfw & aApplication)
+{
+    // see https://github.com/ocornut/imgui/issues/7155#issuecomment-1864823995 
+    // We associate the ImGui context with each window, this way we can restore the
+    // correct context before calling the ImGui callbacks.
+    //
+    // Note: contrary to the recommandation, we keep install_callback=true.
+    // This way, ImGui still captures the previous callback and call them in addition to its logic
+    // (i.e. those installed by ApplicationGlfw that forward to AppInterface)
+
+    // Instantiate the augumented WindowUserData: copy the existing user data
+    // and add the ImGuiContext pointer.
+    GLFWwindow * window = aApplication.getGlfwWindow();
+    graphics::ApplicationGlfw::WindowUserData * previousData =
+        static_cast<graphics::ApplicationGlfw::WindowUserData *>(glfwGetWindowUserPointer(window));
+    mUserData = std::make_unique<WindowUserData>(*previousData);
+    mUserData->mContext = mContext;
+    glfwSetWindowUserPointer(window, mUserData.get());
+
+    // Register our custom function for the 7 required glfw callbacks.
+    glfwSetWindowFocusCallback(window,  implCallback<ImGui_ImplGlfw_WindowFocusCallback, int>);
+    glfwSetCursorEnterCallback(window,  implCallback<ImGui_ImplGlfw_CursorEnterCallback, int>);
+    glfwSetCursorPosCallback(window,    implCallback<ImGui_ImplGlfw_CursorPosCallback, double, double>);
+    glfwSetMouseButtonCallback(window,  implCallback<ImGui_ImplGlfw_MouseButtonCallback, int, int, int>);
+    glfwSetScrollCallback(window,       implCallback<ImGui_ImplGlfw_ScrollCallback, double, double>);
+    glfwSetKeyCallback(window,          implCallback<ImGui_ImplGlfw_KeyCallback, int, int, int, int>);
+    glfwSetCharCallback(window,         implCallback<ImGui_ImplGlfw_CharCallback, unsigned int>);
+}
+
+
 void ImguiUi::renderBackend()
 {
+    // TODO Ad 2024/08/08: we should verify that we are locking the right section.
+    // (Naively, I would suppose we had to lock starting from ImGui::Render())
     std::lock_guard lock{mFrameMutex};
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    // Does not work because of the ImGui custom window_procedure, see #igwp82
+    //ImGui::SetCurrentContext(nullptr);
 }
 
 
 void ImguiUi::newFrame()
 {
+    ImGui::SetCurrentContext(mContext);
+
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplGlfw_NewFrame();

--- a/src/libs/imguiui/imguiui/ImguiUi.h
+++ b/src/libs/imguiui/imguiui/ImguiUi.h
@@ -3,6 +3,7 @@
 #include <imgui.h>
 
 #include <graphics/ApplicationGlfw.h>
+#include <memory>
 #include <mutex>
 
 
@@ -14,6 +15,14 @@ namespace imguiui {
 class ImguiUi
 {
 public:
+    /// @brief Capture the ImGuiContext associated to the GLFWWindow.
+    /// @note Derives from the "base" user data installed by ApplicationGlfw:
+    /// this way, it is still correct to cast to the base type in pre-existing callbacks.
+    struct WindowUserData : public graphics::ApplicationGlfw::WindowUserData
+    {
+        ImGuiContext * mContext; 
+    };
+
     ImguiUi(const graphics::ApplicationGlfw & aApplication);
 
     ~ImguiUi();
@@ -26,11 +35,20 @@ public:
     bool isCapturingKeyboard() const;
     bool isCapturingMouse() const;
 
+    /// @brief Override DearImgui callbacks with our callbacks, which are ImGui context-aware.
+    /// @see https://github.com/ocornut/imgui/issues/7155#issuecomment-1864823995 for rationale.
+    void registerGlfwCallbacks(const graphics::ApplicationGlfw & aApplication);
+
     std::mutex mFrameMutex;
 
 private:
-    // Could be pimpled, but if we do not include imgui.h here, the client will need to do it.
+    // Could be pimpled, but if we do not include imgui.h here,
+    // the client will need to do it to construct GUIs.
+    ImGuiContext * mContext;
     ImGuiIO & mIo;
+
+    // The user data associated to the GLFWWindow corresponding to this.
+    std::unique_ptr<WindowUserData> mUserData = nullptr;
 };
 
 


### PR DESCRIPTION
- Provide a new ApplicationGlfw ctor allowing to share the OpenGL context.
- Scope glfwInit() / glfwTerminate() to a static variable.
- Extend AppInterface with more window controls, keep track if hidden.
- Allow to call registerGlfwCallbacks with nullptr inhibiter.
- Associate ImGui context to gflw window, and redirect required callbacks.
- Upgrade math dependency.
