### PR TITLE
topic/graphics#88 migration conan2

### DIFF
--- a/.github/workflows/develop-build_test_deployrecipe.yml
+++ b/.github/workflows/develop-build_test_deployrecipe.yml
@@ -8,13 +8,10 @@ on:
 
 jobs:
   build-test-deployrecipe:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.7.0
+    #uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.7.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@topic/math#34-migration_conan2
     with:
-      # Disable macos while spdlog crashes its compiler
-      # see: https://github.com/conan-io/conan-center-index/issues/8480
-      os: >-
-        ["ubuntu-24.04", "windows-2022"]
-      deployrecipe_userchannel: adnn/develop
+      deployrecipe_user: adnn
     secrets:
       SHREDROBOT_GITHUB_TOKEN: ${{ secrets.SHREDROBOT_GITHUB_TOKEN }}
       ACTION_CACHENAME: ${{ secrets.ACTION_CACHENAME }}

--- a/.github/workflows/topics-build_test.yml
+++ b/.github/workflows/topics-build_test.yml
@@ -9,12 +9,8 @@ on:
 
 jobs:
   build-test:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.7.0
-    with:
-      # Disable macos while spdlog crashes its compiler
-      # see: https://github.com/conan-io/conan-center-index/issues/8480
-      os: >-
-        ["ubuntu-24.04", "windows-2022"]
+    #uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.7.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@topic/math#34-migration_conan2
     secrets:
       SHREDROBOT_GITHUB_TOKEN: ${{ secrets.SHREDROBOT_GITHUB_TOKEN }}
       ACTION_CACHENAME: ${{ secrets.ACTION_CACHENAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ cmc_include_conan_configuration()
 # Enable the grouping target in folders, when available in IDE.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# see: https://cmake.org/cmake/help/latest/module/CTest.html
+# To be included in the top CMakeLists.txt, creates BUILD_TESTING option (ON by default)
+# Invokes enable_testing() to enable add_test(), unless BUILD_TESTING is OFF.
+# note: Conan can set BUILD_TESTING to OFF through tools.build:skip_test configuration.
+include(CTest)
+
 # Install the top-level package config, allowing to find all sub-components
 include(cmc-install)
 cmc_install_root_component_config(${PROJECT_NAME})

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -44,16 +44,16 @@ class GraphicsConan(ConanFile):
         ("freetype/2.12.1"),
         ("spdlog/1.13.0"),
         ("utfcpp/4.0.1"),
-        ("imgui/1.89.8"),
     )
 
     def requirements(self):
-        self.requires("glfw/3.4", transitive_headers=True)
-        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
-
         self.requires("handy/cb47135273@adnn/develop", transitive_headers=True),
         self.requires("math/cf1d07a75e@adnn/develop", transitive_headers=True),
+
         self.requires("glad/0.1.36", transitive_headers=True),
+        self.requires("glfw/3.4", transitive_headers=True)
+        self.requires("imgui/1.91.5-docking", transitive_headers=True)
+        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
 
 
     # There exist automatic alternatives.

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -42,7 +42,7 @@ class GraphicsConan(ConanFile):
 
     requires = (
         ("freetype/2.12.1"),
-        ("spdlog/1.13.0"),
+        ("spdlog/1.15.0"),
         ("utfcpp/4.0.1"),
     )
 

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -48,7 +48,7 @@ class GraphicsConan(ConanFile):
 
     def requirements(self):
         self.requires("handy/cb47135273@adnn/develop", transitive_headers=True),
-        self.requires("math/cf1d07a75e@adnn/develop", transitive_headers=True),
+        self.requires("math/88c296dc65@adnn/develop", transitive_headers=True),
 
         self.requires("glad/0.1.36", transitive_headers=True),
         self.requires("glfw/3.4", transitive_headers=True)

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -47,8 +47,8 @@ class GraphicsConan(ConanFile):
     )
 
     def requirements(self):
-        self.requires("handy/cb47135273@adnn/develop", transitive_headers=True),
-        self.requires("math/88c296dc65@adnn/develop", transitive_headers=True),
+        self.requires("handy/ef28ae2e1c@adnn", transitive_headers=True),
+        self.requires("math/565b2dd207@adnn", transitive_headers=True),
 
         self.requires("glad/0.1.36", transitive_headers=True),
         self.requires("glfw/3.4", transitive_headers=True)

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -43,7 +43,7 @@ class GraphicsConan(ConanFile):
     requires = (
         ("freetype/2.12.1"),
         ("glad/0.1.36"),
-        ("glfw/3.3.8@adnn/patch"),
+        ("glfw/3.4"),
         ("nlohmann_json/3.11.2"),
         ("spdlog/1.13.0"),
         ("utfcpp/4.0.1"),

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -159,6 +159,9 @@ class GraphicsConan(ConanFile):
         self.cpp_info.components["graphics"].includedirs = ["include/graphics"]
         self.cpp_info.components["graphics"].libs = ["graphics"]
         self.cpp_info.components["graphics"].requires = [
+            "arte",
+            "renderer",
+
             "handy::handy",
             "handy::resource",
             "math::math",
@@ -172,6 +175,8 @@ class GraphicsConan(ConanFile):
         self.cpp_info.components["imguiui"].includedirs = ["include/imguiui"]
         self.cpp_info.components["imguiui"].libs = ["imguiui"]
         self.cpp_info.components["imguiui"].requires = [
+            "graphics",
+
             "imgui::imgui",
         ]
 
@@ -179,6 +184,8 @@ class GraphicsConan(ConanFile):
         self.cpp_info.components["renderer"].includedirs = ["include/renderer"]
         self.cpp_info.components["renderer"].libs = ["renderer"]
         self.cpp_info.components["renderer"].requires = [
+            "arte",
+
             "handy::handy",
             "math::math",
             "glad::glad",

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,8 +1,10 @@
-from conans import ConanFile, tools
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy
+from conan import ConanFile
+from conan.tools.build import can_run, check_min_cppstd
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import copy, update_conandata
+from conan.tools.scm import Git
 
-from os import path
+import os
 
 
 class GraphicsConan(ConanFile):
@@ -12,19 +14,19 @@ class GraphicsConan(ConanFile):
     url = "https://github.com/Adnn/graphics"
     description = "Graphics rendering generic library, both software and with OpenGL"
     topics = ("opengl", "graphics", "2D", "3D")
+
     settings = "os", "compiler", "build_type", "arch"
-    short_paths = True
     options = {
         "shared": [True, False],
-        "build_tests": [True, False],
+        "fPIC": [True, False],
     }
     default_options = {
         "shared": False,
-        "build_tests": False,
-        "glad:gl_version": "4.6", # 4.2 is required for glBindImageTexture()
+        "fPIC": True,
+        "glad/*:gl_version": "4.6", # 4.2 is required for glBindImageTexture()
                                   # 4.6 notably for FRAGMENT_SHADER_INVOCATIONS query
         # Note: macos only provides GL_ARB_texture_storage and GL_ARB_internalformat_query
-        "glad:extensions": ("GL_KHR_debug,"
+        "glad/*:extensions": ("GL_KHR_debug,"
             "GL_ARB_texture_storage,"
             "GL_ARB_clear_texture,"
             "GL_ARB_program_interface_query,"
@@ -35,6 +37,9 @@ class GraphicsConan(ConanFile):
         )
     }
 
+    generators = "CMakeDeps", "CMakeToolchain"
+    revision_mode = "scm"
+
     requires = (
         ("freetype/2.12.1"),
         ("glad/0.1.36"),
@@ -44,24 +49,109 @@ class GraphicsConan(ConanFile):
         ("utfcpp/4.0.1"),
         ("imgui/1.89.8"),
 
-        ("handy/e2b164a804@adnn/develop"),
-        ("math/8c49b882e7@adnn/develop"),
+        ("handy/cb47135273@adnn/develop"),
+        ("math/cf1d07a75e@adnn/develop"),
     )
 
-    build_policy = "missing"
-    generators = "CMakeDeps", "CMakeToolchain"
-    keep_imports = True
+    # There exist automatic alternatives.
+    # see: https://docs.conan.io/2.0/reference/conanfile/methods/config_options.html?highlight=auto_shared_fpic
+    def config_options(self):
+        if self.settings.get_safe("os") == "Windows":
+            self.options.rm_safe("fPIC")
 
 
-    python_requires="shred_conan_base/0.0.5@adnn/stable"
-    python_requires_extend="shred_conan_base.ShredBaseConanFile"
+    # see: https://github.com/conan-io/conan/issues/7530#issuecomment-1420634751
+    def configure(self):
+        if self.options.get_safe("shared"):
+            self.options.rm_safe("fPIC")
 
 
-    def imports(self):
-        # see: https://blog.conan.io/2019/06/26/An-introduction-to-the-Dear-ImGui-library.html
-        # the imgui package is designed this way: consumer has to import desired backends.
-        self.copy("imgui_impl_glfw.cpp",         src="./res/bindings", dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-        self.copy("imgui_impl_opengl3.cpp",      src="./res/bindings", dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-        self.copy("imgui_impl_glfw.h",           src="./res/bindings", dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-        self.copy("imgui_impl_opengl3.h",        src="./res/bindings", dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-        self.copy("imgui_impl_opengl3_loader.h", src="./res/bindings", dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "20")
+
+
+    # Handled at the profile level for the moment
+    #def tool_requires(self):
+    #    self.tool_requires("cmake/[>=3.31]")
+
+
+    def layout(self):
+        # The root of the project is one level above
+        self.folders.root = ".."
+        cmake_layout(self)
+
+
+    def export(self):
+        git = Git(self, self.recipe_folder)
+        # Save the url and commit in conandata.yml
+        # Unsafe atm since it is missing the repository argument,
+        # so we save the coordinates manually
+        #git.coordinates_to_conandata()
+        url, commit = git.get_url_and_commit(repository=True)
+        update_conandata(self, {"scm": {"url": url, "commit": commit}})
+
+
+    def source(self):
+        # we recover the saved url and commit from conandata.yml and use them to get sources
+        git = Git(self)
+        git.checkout_from_conandata_coordinates()
+        git.run("submodule update --init")
+
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        if can_run(self):
+            cmake.test()
+
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+
+    def package_info(self):
+        # Let's bite the bullet and repeate ourselve with a complete cpp_info,
+        # waiting for sufficent Common Package Specification support in Conan an CMake.
+        ## Disable the config package that would otherwise be generated by CMakeDeps
+        #self.cpp_info.set_property("cmake_find_mode", "none")
+        ## Find CMake-generated package config when consuming the (installed) conan package
+        #self.cpp_info.builddirs = [os.path.join("lib", "cmake")]
+
+        self.cpp_info.set_property("cmake_find_mode", "config")
+
+        self.cpp_info.components["arte"].set_property("cmake_target_name", "ad::arte")
+        self.cpp_info.components["arte"].includedirs = ["include/arte"]
+        self.cpp_info.components["arte"].libs = ["arte"]
+
+        self.cpp_info.components["graphics"].set_property("cmake_target_name", "ad::graphics")
+        self.cpp_info.components["graphics"].includedirs = ["include/graphics"]
+        self.cpp_info.components["graphics"].libs = ["graphics"]
+
+        self.cpp_info.components["imguiui"].set_property("cmake_target_name", "ad::imguiui")
+        self.cpp_info.components["imguiui"].includedirs = ["include/imguiui"]
+        self.cpp_info.components["imguiui"].libs = ["imguiui"]
+
+        self.cpp_info.components["renderer"].set_property("cmake_target_name", "ad::renderer")
+        self.cpp_info.components["renderer"].includedirs = ["include/renderer"]
+        self.cpp_info.components["renderer"].libs = ["renderer"]
+
+    #keep_imports = True
+
+
+    #def imports(self):
+    #    # see: https://blog.conan.io/2019/06/26/An-introduction-to-the-Dear-ImGui-library.html
+    #    # the imgui package is designed this way: consumer has to import desired backends.
+    #    files.copy(self, "imgui_impl_glfw.cpp",         src="./res/bindings",
+    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
+    #    files.copy(self, "imgui_impl_opengl3.cpp",      src="./res/bindings",
+    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
+    #    files.copy(self, "imgui_impl_glfw.h",           src="./res/bindings",
+    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
+    #    files.copy(self, "imgui_impl_opengl3.h",        src="./res/bindings",
+    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
+    #    files.copy(self, "imgui_impl_opengl3_loader.h", src="./res/bindings",
+    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -74,9 +74,10 @@ class GraphicsConan(ConanFile):
             check_min_cppstd(self, "20")
 
 
-    # Handled at the profile level for the moment
-    #def tool_requires(self):
-    #    self.tool_requires("cmake/[>=3.31]")
+    # Note: We expect the profile to require it in a specific version
+    # but having it here makes it simpler for external users.
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.23]")
 
 
     def layout(self):
@@ -96,7 +97,7 @@ class GraphicsConan(ConanFile):
 
 
     def source(self):
-        # we recover the saved url and commit from conandata.yml and use them to get sources
+        # recover the url and commit from conandata.yml, use them to get sources
         git = Git(self)
         git.checkout_from_conandata_coordinates()
         git.run("submodule update --init")

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -99,6 +99,20 @@ class GraphicsConan(ConanFile):
         git.run("submodule update --init")
 
 
+    def generate(self):
+        # the imgui package is designed this way: consumer has to import desired backends.
+        # see: https://blog.conan.io/2019/06/26/An-introduction-to-the-Dear-ImGui-library.html
+        # imports() has been removed from Conan 2 (and the blog post above is updated accordingly)
+        # see: https://docs.conan.io/en/1.66/migrating_to_2.0/recipes.html#removed-imports-method
+        imgui_package = os.path.join(self.dependencies["imgui"].package_folder, "res", "bindings")
+        destination = os.path.join(self.build_folder, "conan_imports", "imgui_bindings")
+        copy(self, "imgui_impl_glfw.h",           src=imgui_package, dst=destination)
+        copy(self, "imgui_impl_glfw.cpp",         src=imgui_package, dst=destination)
+        copy(self, "imgui_impl_opengl3.h",        src=imgui_package, dst=destination)
+        copy(self, "imgui_impl_opengl3.cpp",      src=imgui_package, dst=destination)
+        copy(self, "imgui_impl_opengl3_loader.h", src=imgui_package, dst=destination)
+
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
@@ -138,20 +152,3 @@ class GraphicsConan(ConanFile):
         self.cpp_info.components["renderer"].set_property("cmake_target_name", "ad::renderer")
         self.cpp_info.components["renderer"].includedirs = ["include/renderer"]
         self.cpp_info.components["renderer"].libs = ["renderer"]
-
-    #keep_imports = True
-
-
-    #def imports(self):
-    #    # see: https://blog.conan.io/2019/06/26/An-introduction-to-the-Dear-ImGui-library.html
-    #    # the imgui package is designed this way: consumer has to import desired backends.
-    #    files.copy(self, "imgui_impl_glfw.cpp",         src="./res/bindings",
-    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-    #    files.copy(self, "imgui_impl_opengl3.cpp",      src="./res/bindings",
-    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-    #    files.copy(self, "imgui_impl_glfw.h",           src="./res/bindings",
-    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-    #    files.copy(self, "imgui_impl_opengl3.h",        src="./res/bindings",
-    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))
-    #    files.copy(self, "imgui_impl_opengl3_loader.h", src="./res/bindings",
-    #               dst=path.join(self.folders.build, "conan_imports/imgui_backends"))

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -42,16 +42,19 @@ class GraphicsConan(ConanFile):
 
     requires = (
         ("freetype/2.12.1"),
-        ("glad/0.1.36"),
-        ("glfw/3.4"),
-        ("nlohmann_json/3.11.2"),
         ("spdlog/1.13.0"),
         ("utfcpp/4.0.1"),
         ("imgui/1.89.8"),
-
-        ("handy/cb47135273@adnn/develop"),
-        ("math/cf1d07a75e@adnn/develop"),
     )
+
+    def requirements(self):
+        self.requires("glfw/3.4", transitive_headers=True)
+        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
+
+        self.requires("handy/cb47135273@adnn/develop", transitive_headers=True),
+        self.requires("math/cf1d07a75e@adnn/develop", transitive_headers=True),
+        self.requires("glad/0.1.36", transitive_headers=True),
+
 
     # There exist automatic alternatives.
     # see: https://docs.conan.io/2.0/reference/conanfile/methods/config_options.html?highlight=auto_shared_fpic
@@ -140,15 +143,43 @@ class GraphicsConan(ConanFile):
         self.cpp_info.components["arte"].set_property("cmake_target_name", "ad::arte")
         self.cpp_info.components["arte"].includedirs = ["include/arte"]
         self.cpp_info.components["arte"].libs = ["arte"]
+        self.cpp_info.components["arte"].requires = [
+            "handy::handy",
+            "handy::platform",
+            "math::math",
+            "freetype::freetype",
+            "nlohmann_json::nlohmann_json",
+            "spdlog::spdlog",
+        ]
+        #self.cpp_info.components["arte"].set_property("cmake_build_modules", ["lib/cmake/Graphics/arte/arteFindUpstream.cmake"])
+        # Does not work on components, major limitation for us
+        #self.cpp_info.set_property("cmake_build_modules", ["lib/cmake/Graphics/arte/arteFindUpstream.cmake"])
 
         self.cpp_info.components["graphics"].set_property("cmake_target_name", "ad::graphics")
         self.cpp_info.components["graphics"].includedirs = ["include/graphics"]
         self.cpp_info.components["graphics"].libs = ["graphics"]
+        self.cpp_info.components["graphics"].requires = [
+            "handy::handy",
+            "handy::resource",
+            "math::math",
+            "glad::glad",
+            "glfw::glfw",
+            "spdlog::spdlog",
+            "utfcpp::utfcpp",
+        ]
 
         self.cpp_info.components["imguiui"].set_property("cmake_target_name", "ad::imguiui")
         self.cpp_info.components["imguiui"].includedirs = ["include/imguiui"]
         self.cpp_info.components["imguiui"].libs = ["imguiui"]
+        self.cpp_info.components["imguiui"].requires = [
+            "imgui::imgui",
+        ]
 
         self.cpp_info.components["renderer"].set_property("cmake_target_name", "ad::renderer")
         self.cpp_info.components["renderer"].includedirs = ["include/renderer"]
         self.cpp_info.components["renderer"].libs = ["renderer"]
+        self.cpp_info.components["renderer"].requires = [
+            "handy::handy",
+            "math::math",
+            "glad::glad",
+        ]

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(PackageTest CXX)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}>)
-find_package(Graphics REQUIRED COMPONENTS graphics renderer)
+find_package(Graphics REQUIRED COMPONENTS arte graphics renderer)
 
 add_executable(example example.cpp)
-target_link_libraries(example PRIVATE ad::graphics ad::renderer)
+target_link_libraries(example PRIVATE ad::arte ad::graphics ad::renderer)

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -30,9 +30,3 @@ class GraphicsTestConan(ConanFile):
         if can_run(self):
             cmd = os.path.join(self.cpp.build.bindir, "example")
             self.run(cmd, env="conanrun")
-
-
-    #def imports(self):
-    #    self.copy("*.dll", dst="bin", src="bin")
-    #    self.copy("*.dylib*", dst="bin", src="lib")
-    #    self.copy('*.so*', dst='bin', src='lib')

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,17 +1,23 @@
-import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
-from conans import ConanFile, tools
-from conan.tools.cmake import CMake, CMakeToolchain
+import os
 
 
 class GraphicsTestConan(ConanFile):
+    # Simplified recipe version, tailored for test packages
+    # see: https://github.com/conan-io/conan/issues/15247#issuecomment-1850170100
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain"
 
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+
+    def layout(self):
+        cmake_layout(self)
 
 
     def build(self):
@@ -20,12 +26,13 @@ class GraphicsTestConan(ConanFile):
         cmake.build()
 
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.dylib*", dst="bin", src="lib")
-        self.copy('*.so*', dst='bin', src='lib')
-
-
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(".%sexample" % os.sep)
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")
+
+
+    #def imports(self):
+    #    self.copy("*.dll", dst="bin", src="bin")
+    #    self.copy("*.dylib*", dst="bin", src="lib")
+    #    self.copy('*.so*', dst='bin', src='lib')

--- a/conan/test_package/example.cpp
+++ b/conan/test_package/example.cpp
@@ -1,8 +1,10 @@
+#include <arte/Timer.h>
 #include <graphics/Timer.h>
 #include <renderer/VertexSpecification.h>
 
 int main()
 {
+    ad::arte::Image<std::uint8_t> img{ {2, 3}, 2};
     ad::graphics::Timer timer;
     return EXIT_SUCCESS;
 }

--- a/conan/test_package/example.cpp
+++ b/conan/test_package/example.cpp
@@ -1,10 +1,10 @@
-#include <arte/Timer.h>
+#include <arte/Image.h>
 #include <graphics/Timer.h>
 #include <renderer/VertexSpecification.h>
 
 int main()
 {
-    ad::arte::Image<std::uint8_t> img{ {2, 3}, 2};
+    ad::arte::Image<ad::math::sdr::Grayscale> img{ {2, 3}, 2};
     ad::graphics::Timer timer;
     return EXIT_SUCCESS;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,7 @@ add_subdirectory(libs/renderer/renderer)
 add_subdirectory(libs/graphics/graphics)
 add_subdirectory(libs/imguiui/imguiui)
 
-option(BUILD_tests "Build the demo applications" ON)
-if(BUILD_tests)
+if(BUILD_TESTING)
     add_subdirectory(apps/test_commons/test_commons)
     add_subdirectory(apps/graphics_tests/graphics_tests)
 

--- a/src/apps/graphics_tests/graphics_tests/CMakeLists.txt
+++ b/src/apps/graphics_tests/graphics_tests/CMakeLists.txt
@@ -36,4 +36,6 @@ set_target_properties(${TARGET_NAME} PROPERTIES
                       VERSION "${${PROJECT_NAME}_VERSION}"
 )
 
+add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+
 install(TARGETS ${TARGET_NAME})

--- a/src/apps/graphics_tests/graphics_tests/ShaderSource_tests.cpp
+++ b/src/apps/graphics_tests/graphics_tests/ShaderSource_tests.cpp
@@ -14,7 +14,7 @@ using namespace ad;
 using namespace ad::graphics;
 
 
-const std::string gShaderA = 
+const std::string gShaderA =
 R"(#version 310
 
 //#include "ShaderC"
@@ -27,14 +27,14 @@ void main(void)
 })";
 
 
-const std::string gShaderB = 
+const std::string gShaderB =
 R"(int b;//startb
 int foo()
 {}
 // endb)";
 
 
-const std::string gShaderC = 
+const std::string gShaderC =
 R"(int c;)";
 
 
@@ -43,12 +43,14 @@ R"(#version 310
 int b;
 int foo()
 {}
- 
+)"
++ std::string{" "} // We need a space on the newline for the exact match
++ std::string {R"(
 int a; int c;
 void main(void)
 {
 }
-)";
+)"};
 
 
 std::pair<std::unique_ptr<std::istringstream>, std::string>
@@ -67,6 +69,18 @@ lookupStringTable(const std::string aStringName)
 }
 
 
+// Helper to dump the hexadecimal values of bytes in a string
+auto dumpHex = [](std::string_view a) -> std::string
+{
+    std::ostringstream oss;
+    oss.fill('0');
+    for(size_t i = 0; i < a.length(); i++)
+    {
+        oss << std::hex << std::setw(2) << (int)a[i] << " ";
+    }
+    return oss.str();
+};
+
 SCENARIO("Shader code (std::string) include preprocessing.")
 {
     GIVEN("A shader source with #include statements")
@@ -83,6 +97,8 @@ SCENARIO("Shader code (std::string) include preprocessing.")
             THEN("The resulting amalgamation includes the other strings.")
             {
                 ShaderSourceView view{source};
+                INFO("Shader source hex dump:\n" << dumpHex(view.mSource)
+                     << "\nExpected amalgamation hex dump:\n" << dumpHex(gExpectedAmalgamation))
                 REQUIRE(view.mSource == gExpectedAmalgamation);
             }
         }
@@ -148,7 +164,7 @@ SCENARIO("Shader files include preprocessing.")
 SCENARIO("Shader compilation errors mapping.")
 {
     std::unique_ptr<graphics::ApplicationGlfw> glApp;
-    try 
+    try
     {
         glApp = std::make_unique<graphics::ApplicationGlfw>("dummy", math::Size<2, int>{1, 1});
     }
@@ -170,8 +186,8 @@ SCENARIO("Shader compilation errors mapping.")
             {
                 using Catch::Matchers::Contains;
                 CHECK_THROWS_WITH(compileShader(shader, source),
-                                    Contains("helpers.glsl 0(line: 3)")
-                                        && Contains("vert.glsl 0(line: 7)"));
+                                    Contains("helpers.glsl on line 3, column 0")
+                                        && Contains("vert.glsl on line 7, column 0"));
             }
         }
     }

--- a/src/libs/arte/arte/gltf/Gltf.cpp
+++ b/src/libs/arte/arte/gltf/Gltf.cpp
@@ -133,7 +133,7 @@ const std::map<std::string, Accessor::ElementType> gStringToElementType{
 };
 
 
-const std::array<std::string, 4> gTargetPathToString{
+[[maybe_unused]] const std::array<std::string, 4> gTargetPathToString{
     "translation",
     "rotation",
     "scale",
@@ -169,7 +169,7 @@ const std::map<std::string, animation::Sampler::Interpolation> gStringToSamplerI
 };
 
 
-const std::array<std::string, 2> gMimeTypeToString{
+[[maybe_unused]] const std::array<std::string, 2> gMimeTypeToString{
     "image/jpeg",
     "image/png",
 };
@@ -291,7 +291,7 @@ Scene load(const Json & aJson)
         .nodes = makeIndicesVector<Index<Node>>(getOptionalArray(aJson, gTagNodes)),
     };
 }
- 
+
 
 template <>
 Node load(const Json & aNodeObject)
@@ -539,7 +539,7 @@ template <>
 material::PbrMetallicRoughness load(const Json & aJson)
 {
     return {
-        .baseColorFactor = 
+        .baseColorFactor =
             aJson.value<math::hdr::Rgba<float>>(gTagBaseColorFactor,
                                                 material::gDefaultPbr.baseColorFactor),
         .baseColorTexture = loadOptional<TextureInfo>(aJson, gTagBaseColorTexture),
@@ -555,7 +555,7 @@ Material load(const Json & aJson)
 {
     Material result{
         .name = aJson.value(gTagName, ""),
-        .pbrMetallicRoughness = 
+        .pbrMetallicRoughness =
             loadOptional<material::PbrMetallicRoughness>(aJson, gTagPbrMetallicRoughness),
         .normalTexture = loadOptional<NormalTextureInfo>(aJson, gTagNormalTexture),
         .occlusionTexture = loadOptional<OcclusionTextureInfo>(aJson, gTagOcclusionTexture),
@@ -569,7 +569,7 @@ Material load(const Json & aJson)
     }
 
     return result;
-}   
+}
 
 
 template <>
@@ -580,7 +580,7 @@ Texture load(const Json & aJson)
         .source = getOptional<Index<Image>>(aJson, gTagSource),
         .sampler = getOptional<Index<texture::Sampler>>(aJson, gTagSampler),
     };
-}   
+}
 
 
 template <>
@@ -597,7 +597,7 @@ Image load(const Json & aJson)
             return aJson.at(gTagBufferView).get<Index<BufferView>>();
         }
     };
-    
+
     Image image{
         .name = aJson.value(gTagName, ""),
         .dataSource = handleDataSource(aJson),
@@ -609,7 +609,7 @@ Image load(const Json & aJson)
     }
 
     return image;
-}   
+}
 
 
 template <>
@@ -622,7 +622,7 @@ texture::Sampler load(const Json & aJson)
         .wrapS = aJson.value(gTagWrapS, texture::gDefaultSampler.wrapS),
         .wrapT = aJson.value(gTagWrapT, texture::gDefaultSampler.wrapT),
     };
-}   
+}
 
 
 template <>
@@ -681,9 +681,9 @@ Camera load(const Json & aJson)
     return result;
 }
 
-// 
+//
 // Output operators
-// 
+//
 std::string prependNotEmpty(std::string_view aString, std::string aPrefix = " ")
 {
     if (!aString.empty())
@@ -701,8 +701,8 @@ namespace gltf {
 
     std::ostream & operator<<(std::ostream & aOut, const Scene & aScene)
     {
-        return aOut 
-            << "<Scene>" << prependNotEmpty(aScene.name) 
+        return aOut
+            << "<Scene>" << prependNotEmpty(aScene.name)
             << " nodes: " << aScene.nodes;
     }
 

--- a/src/libs/imguiui/imguiui/CMakeLists.txt
+++ b/src/libs/imguiui/imguiui/CMakeLists.txt
@@ -12,11 +12,11 @@ set(${TARGET_NAME}_SOURCES
 )
 
 set(${TARGET_NAME}_IMGUI_BACKENDS
-    ${PROJECT_BINARY_DIR}/conan_imports/imgui_backends/imgui_impl_glfw.cpp
-    ${PROJECT_BINARY_DIR}/conan_imports/imgui_backends/imgui_impl_opengl3.cpp
-    ${PROJECT_BINARY_DIR}/conan_imports/imgui_backends/imgui_impl_glfw.h
-    ${PROJECT_BINARY_DIR}/conan_imports/imgui_backends/imgui_impl_opengl3.h
-    ${PROJECT_BINARY_DIR}/conan_imports/imgui_backends/imgui_impl_opengl3_loader.h
+    ${PROJECT_BINARY_DIR}/conan_imports/imgui_bindings/imgui_impl_glfw.cpp
+    ${PROJECT_BINARY_DIR}/conan_imports/imgui_bindings/imgui_impl_opengl3.cpp
+    ${PROJECT_BINARY_DIR}/conan_imports/imgui_bindings/imgui_impl_glfw.h
+    ${PROJECT_BINARY_DIR}/conan_imports/imgui_bindings/imgui_impl_opengl3.h
+    ${PROJECT_BINARY_DIR}/conan_imports/imgui_bindings/imgui_impl_opengl3_loader.h
 )
 
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR}

--- a/src/libs/imguiui/imguiui/ImguiUi.cpp
+++ b/src/libs/imguiui/imguiui/ImguiUi.cpp
@@ -2,12 +2,15 @@
 
 #include <GLFW/glfw3.h>
 
-#include <cassert>
-#include <imgui_backends/imgui_impl_glfw.h>
-#include <imgui_backends/imgui_impl_opengl3.h>
+#include <imgui_bindings/imgui_impl_glfw.h>
+#include <imgui_bindings/imgui_impl_opengl3.h>
+
 #include <mutex>
 
-// see: 
+#include <cassert>
+
+
+// see:
 // https://github.com/ocornut/imgui/blob/6f7b5d0ee2fe9948ab871a530888a6dc5c960700/backends/imgui_impl_glfw.cpp#L86C1-L92C7
 #ifdef _WIN32
 #undef APIENTRY
@@ -27,7 +30,7 @@ namespace imguiui {
 /// this way, it is still correct to cast to the base type in pre-existing callbacks.
 struct ImguiUi::WindowUserData : public graphics::ApplicationGlfw::WindowUserData
 {
-    ImGuiContext * mContext; 
+    ImGuiContext * mContext;
 #ifdef  _WIN32
     WNDPROC mPreviousWndProc; // The wndproc that was installed by ImGui
 #endif
@@ -55,8 +58,8 @@ namespace {
         // Setup Platform/Renderer backends
         ImGui_ImplGlfw_InitForOpenGL(aWindow, true);
         ImGui_ImplOpenGL3_Init();
-        
-        // on first call NewFrame create all the shader 
+
+        // on first call NewFrame create all the shader
         // and font texture so it NEEDS to be called
         // once before the first backend render
         // Since we want to avoid all call in the render thread
@@ -113,10 +116,10 @@ namespace {
     // This window procedure will restore the context (from user data) before forwarding to previous WndProc.
     static LRESULT CALLBACK contextAwareWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     {
-        ImguiUi::WindowUserData * userdata = 
+        ImguiUi::WindowUserData * userdata =
             (ImguiUi::WindowUserData *)::GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 
-        //std::cerr << "Calling WndProc for window " << hWnd 
+        //std::cerr << "Calling WndProc for window " << hWnd
         //        << " with user data " << userdata
         //        << " on thread " << std::this_thread::get_id()
         //        << "\n";
@@ -166,7 +169,7 @@ Guard ImguiUi::scopeImguiContext() const
 
 void ImguiUi::registerGlfwCallbacks(const graphics::ApplicationGlfw & aApplication)
 {
-    // see https://github.com/ocornut/imgui/issues/7155#issuecomment-1864823995 
+    // see https://github.com/ocornut/imgui/issues/7155#issuecomment-1864823995
     // We associate the ImGui context with each window, this way we can restore the
     // correct context before calling the ImGui callbacks.
     //
@@ -217,7 +220,7 @@ void ImguiUi::registerGlfwCallbacks(const graphics::ApplicationGlfw & aApplicati
         mUserData->mPreviousWndProc = (WNDPROC)::GetWindowLongPtrW(hWnd, GWLP_WNDPROC);
         assert(mUserData->mPreviousWndProc != 0); // would like to assert that it is the function ImGui_ImplGlfw_WndProc
                                                   // But we do not see the symbol, only declared in a cpp file.
-                    
+
         LONG_PTR userdata = ::GetWindowLongPtrW(hWnd, GWLP_USERDATA);
         // We set user data to associate the ImGui context to the window procedure
         // the fact that the userdata was not used already simplifies things.


### PR DESCRIPTION
closes #88.
- Migrate to Conan 2.
- Upgrade glfw to 3.4.
- Restore "import" of imgui bindings from imgui package.
- Fix unit tests.
- Attempt to find the required transitive upstreams.
- Add internal dependencies requires
- Upgrade dear-imgui dependency, use docking branch.
- Upgrade to spdlog 1.15.0.
- Upgrade math dependency.
- Provide a fallback tool_requires to CMake.
- Updage GH workflows.
- Upgrade internal dependencies.
